### PR TITLE
Reverts upgrade to spark 0.9.0

### DIFF
--- a/avocado-core/pom.xml
+++ b/avocado-core/pom.xml
@@ -17,9 +17,8 @@
 
   <properties>
     <java.version>1.6</java.version>
-    <scala.version>2.10.3</scala.version>
+    <scala.version>2.9.3</scala.version>
     <adam.version>0.7.0-SNAPSHOT</adam.version>
-    <scala.artifact.suffix>2.10</scala.artifact.suffix>
   </properties>
 
   <build>
@@ -168,7 +167,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.artifact.suffix}</artifactId>
+      <artifactId>scalatest_${scala.version}</artifactId>
       <version>1.9.2</version>
       <scope>test</scope>
     </dependency>

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/Avocado.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/Avocado.scala
@@ -28,7 +28,7 @@ import edu.berkeley.cs.amplab.adam.avro.{ADAMPileup,
                                          ADAMRecord, 
                                          ADAMVariant, 
                                          ADAMGenotype, 
-                                         ADAMNucleotideContig}
+                                         ADAMFastaNucleotideContig}
 import edu.berkeley.cs.amplab.adam.cli.{AdamSparkCommand, 
                                         AdamCommandCompanion, 
                                         ParquetArgs, 
@@ -73,6 +73,8 @@ class AvocadoArgs extends Args4jBase with ParquetArgs with SparkArgs {
 
 class Avocado (protected val args: AvocadoArgs) extends AdamSparkCommand [AvocadoArgs] with Logging {
   
+  initLogging ()
+
   // companion object to this class - needed for AdamCommand framework
   val companion = Avocado
 
@@ -235,7 +237,7 @@ class Avocado (protected val args: AvocadoArgs) extends AdamSparkCommand [Avocad
     val reads: RDD[ADAMRecord] = sc.adamLoad(args.readInput, Some(classOf[LocusPredicate]))
 
     // load in reference from ADAM file
-    val reference: RDD[ADAMNucleotideContig] = sc.adamLoad(args.referenceInput)
+    val reference: RDD[ADAMFastaNucleotideContig] = sc.adamLoad(args.referenceInput)
 
     // create stats/config item
     val stats = new AvocadoConfigAndStats(sc, args.debug, reads, reference)

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSNP.scala
@@ -155,8 +155,7 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
     }
 
     if (call.length != 0) {
-      assert(call.length == ploidy,
-             "Calls emitted must be consistent with ploidy.")
+      log.info("Writing call info at " + pileupHead.getPosition)
     }
 
     call

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblyPhaser.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblyPhaser.scala
@@ -659,7 +659,7 @@ class Haplotype (val sequence: String) {
         perReadLikelihoods += readLike
         readsLikelihood += readLike
       } catch {
-        case _ : Throwable => {
+        case _ => {
           perReadLikelihoods += 0.0
           readsLikelihood += 0.0
         }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/DefaultPartitioner.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/DefaultPartitioner.scala
@@ -147,8 +147,8 @@ class DefaultPartitionSet (mapping: SortedMap[ReferenceRegion, Int],
                                        " and end at " + region.end + " is outside of the reference contig.")
       }
     } catch {
-      case _ : Throwable => throw new IllegalArgumentException("Received region with contig ID " + region.refId + 
-                                                               ", but do not have a matching reference contig.")
+      case _ => throw new IllegalArgumentException("Received region with contig ID " + region.refId + 
+                                               ", but do not have a matching reference contig.")
     }
   }
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/AvocadoConfigAndStats.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/AvocadoConfigAndStats.scala
@@ -18,12 +18,12 @@ package edu.berkeley.cs.amplab.avocado.stats
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMNucleotideContig}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMFastaNucleotideContig}
 
 class AvocadoConfigAndStats (val sc: SparkContext,
                              val debug: Boolean, 
                              inputDataset: RDD[ADAMRecord],
-                             reference: RDD[ADAMNucleotideContig]) {
+                             reference: RDD[ADAMFastaNucleotideContig]) {
   
   lazy val coverage = ScoreCoverage(inputDataset)
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/GetReferenceContigLengths.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/GetReferenceContigLengths.scala
@@ -18,7 +18,7 @@ package edu.berkeley.cs.amplab.avocado.stats
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMNucleotideContig
+import edu.berkeley.cs.amplab.adam.avro.ADAMFastaNucleotideContig
 
 private[stats] object GetReferenceContigLengths {
   
@@ -28,7 +28,7 @@ private[stats] object GetReferenceContigLengths {
    * @param rdd RDD of reference contigs.
    * @return List of contig lengths.
    */
-  def apply (rdd: RDD[ADAMNucleotideContig]): Map[Int, Long] = {
+  def apply (rdd: RDD[ADAMFastaNucleotideContig]): Map[Int, Long] = {
     rdd.map(c => (c.getContigId.toInt, c.getSequenceLength.toLong)).collect.toMap
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,9 @@
 
   <properties>
     <java.version>1.6</java.version>
-    <scala.version>2.10.3</scala.version>
+    <scala.version>2.9.3</scala.version>
     <adam.version>0.7.0-SNAPSHOT</adam.version>
     <avro.version>1.7.4</avro.version>
-    <scala.artifact.suffix>2.10</scala.artifact.suffix>
   </properties>
 
   <modules>
@@ -186,7 +185,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.artifact.suffix}</artifactId>
+      <artifactId>scalatest_${scala.version}</artifactId>
       <version>1.9.2</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Revert "Upgraded avocado to spark 0.9.0 and scala 2.10.3. On the way, fixed a few small bugs."

This reverts commit d311aac8210c67d439ca7413226dfd98397d5873.
