### PR TITLE
[WIP] Genotype likelihood calc was flipped

### DIFF
--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/MPileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/MPileupCallSimpleSNP.scala
@@ -78,9 +78,9 @@ class MPileupCallSimpleSNP (ploidy: Int,
 
     def compensate (likelihood: Array[(Double, Double, Double)], maf: Double): List[Double] = {
       // compensate likelihoods by major allele frequency - eqn 19 from source
-      List(likelihood(0)._1 * pow((1.0 - maf), 2.0),
+      List(likelihood(0)._1 * pow(maf, 2.0),
            likelihood(0)._2 * 2.0 * maf * (1.0 - maf),
-           likelihood(0)._3 * pow(maf, 2.0))
+           likelihood(0)._3 * pow((1.0 - maf), 2.0))
     }
 
     // compensate genotypes by maf

--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSuite.scala
@@ -25,10 +25,12 @@ import org.scalatest.FunSuite
 import scala.math.abs
 
 class PileupCallSimpleSuite extends FunSuite {
-  
-  def assertFP(a: Double, b: Double) {
+
+  val floatingPointingThreshold = 1e-6
+
+  def assertAlmostEqual(a: Double, b: Double, epsilon : Double = floatingPointingThreshold) {
     assert((a * 0.99 < b && a * 1.01 > b) ||
-           abs(a - b) < 1e6)
+           abs(a - b) < epsilon)
   }
 
   test("Collect the max non-ref base for homozygous SNP") {
@@ -143,12 +145,12 @@ class PileupCallSimpleSuite extends FunSuite {
     val expected = List((8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999)) / 8.0,
                         ((0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999) +
                          (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999)) / 8.0,
-                        8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999) / 8.0)
+                        8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999) / 8.0).reverse
 
     val scored = call.scoreGenotypeLikelihoods(pl)
 
     for (i <- 0 to 2) {
-      assertFP(expected(i), scored(i))
+      assertAlmostEqual(expected(i), scored(i))
     }
   }
 
@@ -177,17 +179,17 @@ class PileupCallSimpleSuite extends FunSuite {
                     .setCountAtPosition(1)
                     .build()
                   )
+    //TODO(arahuja) test is not correct as multiplying probabilities is not exactly the same as averaging qual scores
+    val expected = List((8.0 * ((0.999 * 0.999) * (0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999))) / 8.0,
 
-    val expected = List((8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * (1.0 - 0.999 * 0.9999))) / 8.0,
-                        (((0.999 * 0.999 * 0.9999 * 0.9999) +
-                          (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999)) * 
-                         ((1.0 - 0.999 * 0.9999) + (0.999 * 0.9999))) / 8.0,
-                        8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (0.999 * 0.9999) / 8.0)
+      ((0.999 * 0.999 + (1.0 - 0.999 * 0.999)) *  (0.9999 * 0.9999 + (1.0 - 0.9999 * 0.9999))
+        *  ((1.0 - 0.999 * 0.9999) + (0.999 * 0.9999) )) / 8.0,
+      (8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (0.999 * 0.9999)) / 8.0).reverse
 
     val scored = call.scoreGenotypeLikelihoods(pl)
 
     for (i <- 0 to 2) {
-      assertFP(expected(i), scored(i))
+      assertAlmostEqual(expected(i), scored(i), 1e-3)
     }
   }
 
@@ -220,13 +222,13 @@ class PileupCallSimpleSuite extends FunSuite {
     val expected = List(8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999) / 8.0,
                         ((0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999) +
                          (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999)) / 8.0,
-                        (8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999)) / 8.0)
+                        (8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999)) / 8.0).reverse
    
 
     val scored = call.scoreGenotypeLikelihoods(pl)
 
     for (i <- 0 to 2) {
-      assertFP(expected(i), scored(i))
+      assertAlmostEqual(expected(i), scored(i))
     }
   }
 


### PR DESCRIPTION
Genotype likelihood calc was incorrect as  g = 0 should not refer to homozygous reference but homozygous alternate (equivalently g = # of reference bases in allele) (at least according to the algorithm implemented)

The tests were passing because of a bug in the floating point equals function where the threshold was 1e6 instead of 1e-6

There are still some issues in the test on floating point accuracy as the order of operations affects the outcome and tests are written as multiplication of error probabilities which not the same as the probability of the average of two quality scores.

This can be cleaned up some more probably but I wanted to bring the issue up to get some feedback
