### PR TITLE
Updating to point to ADAM 0.7.2 snapshot release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <name>avocado: A Variant Caller, Distributed</name>
 
   <properties>
-    <adam.version>0.7.1-SNAPSHOT</adam.version>
+    <adam.version>0.7.2-SNAPSHOT</adam.version>
     <avro.version>1.7.4</avro.version>
     <java.version>1.6</java.version>
     <scala.version>2.10.3</scala.version>


### PR DESCRIPTION
Small update to pom.xml to change to point at the current ADAM 0.7.2 snapshot release after the 0.7.1 release.
