### PR TITLE
Clean up assembler snp calls

### DIFF
--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblySuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblySuite.scala
@@ -16,12 +16,12 @@
 
 package edu.berkeley.cs.amplab.avocado.calls.reads
 
-import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
 import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, VariantType, ADAMGenotypeAllele}
 import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import scala.collection.JavaConversions._
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
 import org.scalatest.FunSuite
+import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, Buffer, HashMap, HashSet, PriorityQueue, StringBuilder}
 
 class ReadCallAssemblySuite extends FunSuite {
@@ -45,6 +45,9 @@ class ReadCallAssemblySuite extends FunSuite {
       .setMapq(60)
       .setQual(qualities.map(_.toChar.toString).reduce(_ + _))
       .setMismatchingPositions(mdtag)
+      .setReferenceName("chr1")
+      .setReferenceId(1)
+      .setRecordGroupSample("sample")
       .build()
   }
 
@@ -183,7 +186,28 @@ class ReadCallAssemblySuite extends FunSuite {
     assert(haplotypes.contains("TACCATGTAA"))
   }
 
-  test("Call simple het SNP, 5x coverage") {
+  test("\"Call\" hom ref, ~10x coverage") {
+    val reference = "TACCAATGTAA"
+    val read0 = make_read("TACCAAT"    , 0L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 0)
+    val read1 = make_read( "ACCAATG"   , 1L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 1)
+    val read2 = make_read(  "CCAATGT"  , 2L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 2)
+    val read3 = make_read(   "CAATGTA" , 3L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 3)
+    val read4 = make_read(    "AATGTAA", 4L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 4)
+    val read5 = make_read("TACCAAT"    , 0L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 5)
+    val read6 = make_read( "ACCAATG"   , 1L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 6)
+    val read7 = make_read(  "CCAATGT"  , 2L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 7)
+    val read8 = make_read(   "CAATGTA" , 3L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 8)
+    val read9 = make_read(    "AATGTAA", 4L, "7M", "7", 7, Seq(50, 50, 50, 50, 50, 50, 50), 9)
+
+    val readBucket = Seq(read0, read1, read2, read3, read4, read5, read6, read7, read8, read9)
+    val kmerGraph = rcap_short.assemble(readBucket, reference)
+    
+    val variants = rcap_short.phaseAssembly(readBucket, kmerGraph, reference)
+
+    assert(variants.length === 0)
+  }
+
+  test("Call simple het SNP, ~10x coverage") {
     val reference = "TACCAATGTAA"
     val read0 = make_read("TACCCAT"    , 0L, "7M", "4A2", 7, Seq(50, 50, 50, 50, 50, 50, 50), 0)
     val read1 = make_read( "ACCCATG"   , 1L, "7M", "3A3", 7, Seq(50, 50, 50, 50, 50, 50, 50), 1)
@@ -206,8 +230,38 @@ class ReadCallAssemblySuite extends FunSuite {
     assert(variants.head.variant.variant.getReferenceAllele === "A")
     assert(variants.head.variant.variant.getVariantAllele === "C")
     assert(variants.head.variant.variant.getVariantType === VariantType.SNP)
-    assert(variants.head.genotypes.head.getAlleles.length === 2)
-    assert(variants.head.genotypes.head.getAlleles.head === ADAMGenotypeAllele.Ref)
-    assert(variants.head.genotypes.head.getAlleles.tail === ADAMGenotypeAllele.Alt)
+    val alleles: List[ADAMGenotypeAllele] = asScalaBuffer(variants.head.genotypes.head.getAlleles).toList
+    assert(alleles.length === 2)
+    assert(alleles.head === ADAMGenotypeAllele.Ref)
+    assert(alleles.last === ADAMGenotypeAllele.Alt)
+  }
+
+  test("Call simple hom SNP, ~10x coverage") {
+    val reference = "TACCAATGTAA"
+    val read0 = make_read("TACCCAT"    , 0L, "7M", "4A2", 7, Seq(50, 50, 50, 50, 50, 50, 50), 0)
+    val read1 = make_read( "ACCCATG"   , 1L, "7M", "3A3", 7, Seq(50, 50, 50, 50, 50, 50, 50), 1)
+    val read2 = make_read(  "CCCATGT"  , 2L, "7M", "2A4", 7, Seq(50, 50, 50, 50, 50, 50, 50), 2)
+    val read3 = make_read(   "CCATGTA" , 3L, "7M", "1A5", 7, Seq(50, 50, 50, 50, 50, 50, 50), 3)
+    val read4 = make_read(    "CATGTAA", 4L, "7M", "0A6", 7, Seq(50, 50, 50, 50, 50, 50, 50), 4)
+    val read5 = make_read("TACCCAT"    , 0L, "7M", "4A2", 7, Seq(50, 50, 50, 50, 50, 50, 50), 5)
+    val read6 = make_read( "ACCCATG"   , 1L, "7M", "3A3", 7, Seq(50, 50, 50, 50, 50, 50, 50), 6)
+    val read7 = make_read(  "CCCATGT"  , 2L, "7M", "2A4", 7, Seq(50, 50, 50, 50, 50, 50, 50), 7)
+    val read8 = make_read(   "CCATGTA" , 3L, "7M", "1A5", 7, Seq(50, 50, 50, 50, 50, 50, 50), 8)
+    val read9 = make_read(    "CATGTAA", 4L, "7M", "0A6", 7, Seq(50, 50, 50, 50, 50, 50, 50), 9)
+
+    val readBucket = Seq(read0, read1, read2, read3, read4, read5, read6, read7, read8, read9)
+    val kmerGraph = rcap_short.assemble(readBucket, reference)
+    
+    val variants = rcap_short.phaseAssembly(readBucket, kmerGraph, reference)
+
+    assert(variants.length === 1)
+    assert(variants.head.position.pos === 4L)
+    assert(variants.head.variant.variant.getReferenceAllele === "A")
+    assert(variants.head.variant.variant.getVariantAllele === "C")
+    assert(variants.head.variant.variant.getVariantType === VariantType.SNP)
+    val alleles: List[ADAMGenotypeAllele] = asScalaBuffer(variants.head.genotypes.head.getAlleles).toList
+    assert(alleles.length === 2)
+    assert(alleles.head === ADAMGenotypeAllele.Alt)
+    assert(alleles.last === ADAMGenotypeAllele.Alt)
   }
 }


### PR DESCRIPTION
Some basic cleanup on the assembler to get SNP calls cleaned up. This commit adds several tests, cleans up de Brujin graph creation and variant emittance, and starts to clean up HMM alignment. Follow on work will focus on:
- Cleaning up HMM alignment/scoring for indels
- Cleaning internal assembler data structures
