### PR TITLE
Updated variant callers to remove variant type field, as it has been removed in ADAM

### DIFF
--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblyPhaser.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblyPhaser.scala
@@ -1004,7 +1004,6 @@ class ReadCallAssemblyPhaser extends ReadCall {
         .setReferenceAllele(refAllele)
         .setVariantAllele(altAllele)
         .setPosition(refPos)
-        .setVariantType(varType)
         .build
       val genotypeRef = ADAMGenotype.newBuilder ()
         .setVariant(variant)
@@ -1031,7 +1030,6 @@ class ReadCallAssemblyPhaser extends ReadCall {
         .setReferenceAllele(refAllele)
         .setVariantAllele(altAllele)
         .setPosition(refPos)
-        .setVariantType(varType)
         .build
       val genotypeNonRef0 = ADAMGenotype.newBuilder ()
         .setVariant(variant)


### PR DESCRIPTION
This PR applies changes to avocado that are needed to compile after PR#187 merged into ADAM.
