### PR TITLE
Remove lingering references to VariantType, which was removed from ADAM

### DIFF
--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSNP.scala
@@ -16,7 +16,7 @@
 
 package edu.berkeley.cs.amplab.avocado.calls.pileup
 
-import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMContig, ADAMGenotype, ADAMPileup, ADAMVariant, VariantType}
+import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMContig, ADAMGenotype, ADAMPileup, ADAMVariant}
 import edu.berkeley.cs.amplab.adam.models.{ADAMRod, ADAMVariantContext}
 import edu.berkeley.cs.amplab.adam.util.PhredUtils
 import edu.berkeley.cs.amplab.avocado.calls.VariantCallCompanion
@@ -96,7 +96,6 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
         .setPosition(pileupHead.getPosition)
         .setReferenceAllele(pileupHead.getReferenceBase.toString)
         .setVariantAllele(maxNonRefBase.get.toString)
-        .setVariantType(VariantType.SNP)
         .build
       val genotypeRef = ADAMGenotype.newBuilder()
         .setVariant(variant)
@@ -126,7 +125,6 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
         .setPosition(pileupHead.getPosition)
         .setReferenceAllele(pileupHead.getReferenceBase.toString)
         .setVariantAllele(maxNonRefBase.get.toString)
-        .setVariantType(VariantType.SNP)
         .build
       val genotypeNonRef0 = ADAMGenotype.newBuilder()
         .setVariant(variant)

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblyPhaser.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallAssemblyPhaser.scala
@@ -16,7 +16,7 @@
 
 package edu.berkeley.cs.amplab.avocado.calls.reads
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMGenotype, ADAMRecord, ADAMVariant, VariantType}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMGenotype, ADAMRecord, ADAMVariant}
 import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
@@ -31,6 +31,11 @@ import org.apache.spark.rdd.{RDD}
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, Buffer, HashMap, HashSet, PriorityQueue, StringBuilder}
 import scala.math._
+
+object VariantType extends scala.Enumeration {
+  type VariantType = Value
+  val SNP, MNP, Insertion, Deletion = Value
+}
 
 object ReadCallAssemblyPhaser extends VariantCallCompanion {
 
@@ -967,7 +972,7 @@ class ReadCallAssemblyPhaser extends ReadCall {
    * @param refId ID for reference.
    * @return List of genotypes.
    */
-  def emitVariantCall (varType: VariantType, 
+  def emitVariantCall (varType: VariantType.VariantType,
                        varLength: Int, 
                        varOffset: Int, 
                        refOffset: Int, 


### PR DESCRIPTION
There were some lingering references to VariantType that https://github.com/bigdatagenomics/avocado/pull/29 seems to have missed. I should have checked that before merging in that PR -- sorry about that. This PR removes the lingering VariantType references so avocado can compile with the latest ADAM.
