### PR TITLE
Add input stage to sample configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@
 *.adam*
 *.vcf*
 target
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Mac
+.DS_Store

--- a/avocado-sample-configs/assembler.properties
+++ b/avocado-sample-configs/assembler.properties
@@ -1,4 +1,8 @@
 {
+  AlignedReads =
+  {
+  }
+
   assembler = 
   {
   }

--- a/avocado-sample-configs/basic-config.properties
+++ b/avocado-sample-configs/basic-config.properties
@@ -1,4 +1,7 @@
 {
+  AlignedReads =
+  {
+  }
   sort = 
   {
   }


### PR DESCRIPTION
Default InputStage is AlignedReads and that needs subnode configuration defined.

This fixes that to allow the sample configs to run, but probably not the best fix.  Does InputStage need any configuration?  It doesn't use it now, but I assume its there for future possible inputs, I'm just not sure what the possibilities are.

Additionally some clean up import and prints to logging.
