### PR TITLE
Updated avocado to move to org.bdgenomics, and to move to ADAM 0.8.1-SNAPSHOT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,30 @@
+# avocado #
+* ISSUE [37](https://github.com/bigdatagenomics/adam/pull/37): 
+* ISSUE [28](https://github.com/bigdatagenomics/adam/pull/28): Fix build warnings
+* ISSUE [34](https://github.com/bigdatagenomics/adam/pull/34): 
+* ISSUE [32](https://github.com/bigdatagenomics/adam/pull/32): ReferenceRegion represents a contiguous genomic region.
+* ISSUE [30](https://github.com/bigdatagenomics/adam/pull/30): Suppress parquet logging in FieldEnumerationSuite
+* ISSUE [29](https://github.com/bigdatagenomics/adam/pull/29): 
+* ISSUE [21](https://github.com/bigdatagenomics/adam/pull/21): Adding rod functionality: a specialized grouping of pileup data.
+* ISSUE [26](https://github.com/bigdatagenomics/adam/pull/26): Fix unmapped reads in sequence dictionary
+* ISSUE [24](https://github.com/bigdatagenomics/adam/pull/24): Add unit tests for marking duplicates
+* ISSUE [23](https://github.com/bigdatagenomics/adam/pull/23): Generalizing the Projection class
+* ISSUE [22](https://github.com/bigdatagenomics/adam/pull/22): Add a unit test for sorting reads
+* ISSUE [20](https://github.com/bigdatagenomics/adam/pull/20): Added Apache License 2.0 boilerplate to tops of all the GB-(c) files
+* ISSUE [17](https://github.com/bigdatagenomics/adam/pull/17): Fix transform -sort_reads partitioning. Add -coalesce option to transform.
+* ISSUE [18](https://github.com/bigdatagenomics/adam/pull/18): "Flat" Representation of Genotype/Variants
+* ISSUE [16](https://github.com/bigdatagenomics/adam/pull/16): Fixing an issue in pileup generation and in the MdTag util.
+* ISSUE [15](https://github.com/bigdatagenomics/adam/pull/15): Tweaks 1
+* ISSUE [14](https://github.com/bigdatagenomics/adam/pull/14): Converting some of the Option() calls to Some()
+* ISSUE [13](https://github.com/bigdatagenomics/adam/pull/13): Cleaning up VCF<->ADAM pipeline
+* ISSUE [12](https://github.com/bigdatagenomics/adam/pull/12): Subclass testing bug in AdamContext.adamLoad
+* ISSUE [11](https://github.com/bigdatagenomics/adam/pull/11): Missing brackets in VcfConverter.getType
+* ISSUE [10](https://github.com/bigdatagenomics/adam/pull/10): Moved record field name enum over to the projections package.
+* ISSUE [8](https://github.com/bigdatagenomics/adam/pull/8): Fixes to sorting in ReferencePosition
+* ISSUE [7](https://github.com/bigdatagenomics/adam/pull/7): ADAM variant and genotype formats; and a VCF->ADAM converter
+* ISSUE [6](https://github.com/bigdatagenomics/adam/pull/6): Adding in implicit conversion functions for going between Java and Scala...
+* ISSUE [4](https://github.com/bigdatagenomics/adam/pull/4): New SparkFunSuite test support class, logging util and new BQSR test.
+* ISSUE [3](https://github.com/bigdatagenomics/adam/pull/3): Adding in implicit conversion functions for going between Java and Scala...
+* ISSUE [5](https://github.com/bigdatagenomics/adam/pull/5): Modified reads2ref code to fix performance issue.
+* ISSUE [2](https://github.com/bigdatagenomics/adam/pull/2): Update from Spark 0.7.3 to 0.8.0-incubating
+* ISSUE [1](https://github.com/bigdatagenomics/adam/pull/1): Fix scalatest configuration and fix unit tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+How to contribute to avocado
+=========================
+
+Thank you for sharing your code with the avocado project. We appreciate your contribution!
+
+## Join the mailing list and our IRC channel
+
+If you're not already on the avocado developers list, [take a minute to join](http://bigdatagenomics.github.io/mail/).
+It would be great if you'd introduce yourself to the group but it's not required. You can just
+let your code do the talking for you if you like.
+
+You can find us on Freenode IRC in the #adamdev room.
+
+## Check the issue tracker
+
+Before you write too much code, check the [open issues in the avocado issue tracker](https://github.com/bigdatagenomics/avocado/issues?state=open)
+to see if someone else has already filed an issue related to your work or is already working on it. If not, go ahead and 
+[open a new issue](https://github.com/bigdatagenomics/avocado/issues/new).
+
+## Announce your work on the mailing list
+
+Shoot us a quick email on the mailing list letting us know what you're working on. There
+will likely be people on the list who can give you tips about where to find relevant 
+source or alert you to other planned changes that might effect your work.
+
+If the work you're proposing makes substantive changes to avocado, you may be asked to attach a design document
+to your issue in the issue tracker. This document should provide a high-level explanation of your design, clearly define the goal
+of the new design and explain the expected effects on performance, APIs, etc. This document is meant to save you time
+as it allows the team a chance to provide feedback on the proposes changes. It's likely we can help you find a way
+to achieve your goals with less work. The document also allows the team to prepare for large changes to the code
+base. We welcome change but also want to ensure that code quality is kept high.
+
+## Submit your pull request
+
+Github provides a nice [overview on how to create a pull request](https://help.github.com/articles/creating-a-pull-request).
+
+Some general rules to follow:
+
+* Do your work in [a fork](https://help.github.com/articles/fork-a-repo) of the avocado repo.
+* Create a branch for each feature/bug in avocado that you're working on. These branches are often called "feature"
+or "topic" branches.
+* Use your feature branch in the pull request. Any changes that you push to your feature branch will automatically
+be shown in the pull request.
+* If your pull request fixes an issue, reference the issue so that it will [be closed when your pull request is merged](https://github.com/blog/1506-closing-issues-via-pull-requests)
+* Keep your pull requests as small as possible. Large pull requests are hard to review. Try to break up your changes
+into self-contained and incremental pull requests, if need be, and reference dependent pull requests, e.g. "This pull
+request builds on request #92. Please review #92 first."
+* The first line of commit messages should be a short (<80 character) summary, followed by an empty line and then,
+optionally, any details that you want to share about the commit.
+* Include unit tests with your pull request. We love tests and [use Jenkins](https://amplab.cs.berkeley.edu/jenkins/)
+to check every pull request and commit. Just look for files in the avocado repo that end in "*Suite.scala", 
+e.g. avocadoContextSuite.scala, to see examples of how to write tests.
+* Please try to follow the existing coding style. Sources can be automatically formated by running "mvn process-sources".
+* Make sure to add a copyright header to all new files (see below).
+
+### Update CHANGES.md file
+
+* The CHANGES.md file is updated to indicate changes that are resolved for the next release.  Please update the file with your commit.
+
+## Copyright header and Licensing
+
+avocado is released under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+Any new files added need to have a header with a license like the following, e.g.
+
+'''
+/**
+ * Copyright (c) [year]. [insert your company or name here]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'''

--- a/avocado-core/pom.xml
+++ b/avocado-core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.berkeley.cs.amplab.avocado</groupId>
+    <groupId>org.bdgenomics.avocado</groupId>
     <artifactId>avocado</artifactId>
     <version>0.0.2</version>
     <relativePath>../pom.xml</relativePath>
@@ -29,7 +29,7 @@
           <transformers>
             <transformer
                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>edu.berkeley.cs.amplab.avocado.Avocado</mainClass>
+              <mainClass>org.bdgenomics.avocado.Avocado</mainClass>
             </transformer>
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>reference.conf</resource>
@@ -149,17 +149,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>edu.berkeley.cs.amplab.adam</groupId>
+      <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-format</artifactId>
       <version>${adam.version}</version>
     </dependency>
     <dependency>
-      <groupId>edu.berkeley.cs.amplab.adam</groupId>
+      <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-core</artifactId>
       <version>${adam.version}</version>
     </dependency>
     <dependency>
-      <groupId>edu.berkeley.cs.amplab.adam</groupId>
+      <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-cli</artifactId>
       <version>${adam.version}</version>
     </dependency>

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/algorithms/debrujin/KmerGraph.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/algorithms/debrujin/KmerGraph.scala
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.algorithms.debrujin
+package org.bdgenomics.avocado.algorithms.debrujin
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, PriorityQueue}
+import org.bdgenomics.adam.avro.ADAMRecord
+import scala.collection.mutable.{ ArrayBuffer, HashMap, HashSet, PriorityQueue }
 
 /**
  * For our purposes, a read is a list of kmers.
  *
  * @param record Read to build assembly read from.
  */
-case class AssemblyRead (record: ADAMRecord) {
+case class AssemblyRead(record: ADAMRecord) {
 }
 
 /**
@@ -32,7 +32,7 @@ case class AssemblyRead (record: ADAMRecord) {
  *
  * @param string Kmer base string.
  */
-case class KmerPrefix (string: String) {
+case class KmerPrefix(string: String) {
 
   def equals(kp: KmerPrefix): Boolean = string == kp.string
 }
@@ -43,7 +43,7 @@ case class KmerPrefix (string: String) {
  * @param prefix Prefix for kmer of length (k - 2)
  * @param suffix Last base of kmer
  */
-case class Kmer (prefix: KmerPrefix, suffix: Char) {
+case class Kmer(prefix: KmerPrefix, suffix: Char) {
   var reads = new HashSet[AssemblyRead]
   var mult: Int = 0
   var isCanon: Boolean = false
@@ -66,11 +66,11 @@ case class Kmer (prefix: KmerPrefix, suffix: Char) {
 }
 
 /**
- *class representing a path made of kmers.
+ * class representing a path made of kmers.
  *
  * @param edges Edges of kmer graph.
  */
-class KmerPath (val edges: Seq[Kmer]) {
+class KmerPath(val edges: Seq[Kmer]) {
 
   val multSum: Int = edges.map(_.mult).fold(0)(_ + _)
 
@@ -79,7 +79,7 @@ class KmerPath (val edges: Seq[Kmer]) {
    *
    * @return String representing haplotype from kmers.
    */
-  def asHaplotypeString (): String = {
+  def asHaplotypeString(): String = {
     var sb = ""
     if (edges.length > 0) {
       sb += edges(0).prefix.string
@@ -87,7 +87,8 @@ class KmerPath (val edges: Seq[Kmer]) {
         sb += e.suffix
       }
       sb
-    } else {
+    }
+    else {
       "" // TODO should throw exception
     }
   }
@@ -110,12 +111,14 @@ object KmerPathOrdering extends Ordering[KmerPath] {
    * @param path2 Kmer path to evaluate.
    * @return (-1, 0, 1) if path1 has mult sum (less than, equal, greater than) path2.
    */
-  def compare (path1: KmerPath, path2: KmerPath): Int = {
+  def compare(path1: KmerPath, path2: KmerPath): Int = {
     if (path1.multSum < path2.multSum) {
       -1
-    } else if (path1.multSum > path2.multSum) {
+    }
+    else if (path1.multSum > path2.multSum) {
       1
-    } else {
+    }
+    else {
       0
     }
   }
@@ -128,7 +131,7 @@ object KmerPathOrdering extends Ordering[KmerPath] {
  * @param readLen Read length.
  * @param regionLen Length of the active region.
  */
-class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
+class KmerGraph(kLen: Int, readLen: Int, regionLen: Int, reference: String) {
   val spurThreshold = kLen // TODO(peter, 11/26) how to choose thresh?
 
   //var reads: HashMap[String,AssemblyRead] = null
@@ -137,13 +140,13 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
   // source/sink kmers
   val sourceKmer = new Kmer(new KmerPrefix(reference.take(kLen - 1)), reference.drop(kLen - 1).head)
   val sinkKmer = new Kmer(new KmerPrefix(reference.dropRight(1).takeRight(kLen - 1)),
-                          reference.last)
+    reference.last)
 
   // The actual kmer graph consists of unique K-1 prefixes and kmers connected
   // by vertices.
-  // TODO: Remove KmerPrefix class 
-  var prefixes = new HashMap[String,KmerPrefix]
-  var kmers = new HashMap[KmerPrefix,HashSet[Kmer]]
+  // TODO: Remove KmerPrefix class
+  var prefixes = new HashMap[String, KmerPrefix]
+  var kmers = new HashMap[KmerPrefix, HashSet[Kmer]]
 
   // Paths through the kmer graph are in order of decreasing total mult.
   var allPaths = new PriorityQueue[KmerPath]()(KmerPathOrdering)
@@ -153,7 +156,7 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
    *
    * @param r Read to add kmers from.
    */
-  def insertReadKmers (r: AssemblyRead): Unit = {
+  def insertReadKmers(r: AssemblyRead): Unit = {
     // Construct L - K + 1 kmers, initially connected to the source and sink.
     val readSeq = r.record.getSequence.toString
     val offsets = 0 until readLen - kLen + 1
@@ -168,7 +171,7 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
       if (kmerSet.forall(!_.equals(k))) {
         kmerSet += k
       }
-      
+
       // increase multiplicity per kmer seen and attach read evidence
       kmerSet.filter(_.equals(k)).foreach(km => {
         km.incrementMult
@@ -210,19 +213,19 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
    *
    * @param readGroup Sequence of reads to add.
    */
-  def insertReads (readGroup: Seq[ADAMRecord]): Unit = {
+  def insertReads(readGroup: Seq[ADAMRecord]): Unit = {
     reads = readGroup.map(x => new AssemblyRead(x))
     reads.foreach(r => insertReadKmers(r))
   }
 
-  def exciseKmer (k: Kmer): Unit = {
+  def exciseKmer(k: Kmer): Unit = {
     // TODO(peter, 11/27) for spur removal.
   }
 
   /**
    * Builds graph.
    */
-  def connectGraph (): Unit = {
+  def connectGraph(): Unit = {
     /*
     // Consolidate equivalent kmers.
     for ((prefix, ks) <- kmers) {
@@ -268,7 +271,7 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
   /**
    * Removes spurs from graph.
    */
-  def removeSpurs (): Unit = {
+  def removeSpurs(): Unit = {
     // Remove all kmer paths with length <= spurThreshold, connected to the
     // graph source and sink.
     // TODO(peter, 11/27) make sure the path lengths are initialized and
@@ -312,18 +315,19 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
   /**
    * Performs depth first search and scores all paths through the final graph.
    */
-  def enumerateAllPaths (): Unit = {
+  def enumerateAllPaths(): Unit = {
     // TODO(peter, 12/9) arbitrary max assembly bound.
     //TODO change to use list cons
     val maxDepth = regionLen + readLen - kLen + 1
     var edges = new ArrayBuffer[Kmer]
     var paths = List[KmerPath]()
 
-    def allPathsDFS (v: KmerPrefix, depth: Int): Unit = {
+    def allPathsDFS(v: KmerPrefix, depth: Int): Unit = {
       if (v.equals(sinkKmer.nextPrefix)) {
         val path = new KmerPath(edges.clone.toSeq)
         paths = path :: paths
-      } else if (depth <= maxDepth) {
+      }
+      else if (depth <= maxDepth) {
         for (k <- kmers.getOrElse(v, Set[Kmer]())) {
           edges += k
           allPathsDFS(k.nextPrefix, depth + 1)
@@ -342,5 +346,5 @@ class KmerGraph (kLen: Int, readLen: Int, regionLen: Int, reference: String) {
    *
    * @return Sorted priority queue of paths in the graph.
    */
-  def getAllPaths (): PriorityQueue[KmerPath] = allPaths
+  def getAllPaths(): PriorityQueue[KmerPath] = allPaths
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/algorithms/hmm/HMMAligner.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/algorithms/hmm/HMMAligner.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.algorithms.hmm
+package org.bdgenomics.avocado.algorithms.hmm
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import org.bdgenomics.adam.avro.ADAMRecord
 import scala.collection.mutable.ArrayBuffer
 import scala.math._
 
@@ -75,7 +75,7 @@ class HMMAligner {
    * @param testQualities String of qualities. Not currently used.
    * @return True if sequence has variants.
    */
-  def alignSequences (refSequence: String, testSequence: String, testQualities: String): Boolean = {
+  def alignSequences(refSequence: String, testSequence: String, testQualities: String): Boolean = {
 
     def fpCompare(a: Double, b: Double, eps: Double): Boolean = abs(a - b) <= eps
 
@@ -91,7 +91,8 @@ class HMMAligner {
       traceMatches = new Array[Char](matSize)
       traceInserts = new Array[Char](matSize)
       traceDeletes = new Array[Char](matSize)
-    } else if (matSize <= 1 || oldMatSize <= 1) {
+    }
+    else if (matSize <= 1 || oldMatSize <= 1) {
       matches = new Array[Double](1)
       inserts = new Array[Double](1)
       deletes = new Array[Double](1)
@@ -118,7 +119,8 @@ class HMMAligner {
             // TODO(peter, 12/7) there is a second constant term to the prior...
             val prior = if (testBase == refBase) {
               matchPrior / (indelPrior * indelPrior)
-            } else {
+            }
+            else {
               mismatchPrior / (indelPrior * indelPrior)
             }
             val idx = (i - 1) * stride + (j - 1)
@@ -128,31 +130,38 @@ class HMMAligner {
             val mMax = max(mMatch, max(mInsert, mDelete)) + prior
             val t = if (fpCompare(mMax, mMatch, 0.01)) {
               'M'
-            } else if (fpCompare(mMax, mInsert, 0.01)) {
+            }
+            else if (fpCompare(mMax, mInsert, 0.01)) {
               'I'
-            } else if (fpCompare(mMax, mDelete, 0.01)) {
+            }
+            else if (fpCompare(mMax, mDelete, 0.01)) {
               'D'
-            } else {
+            }
+            else {
               '.'
             }
             (mMax, t)
-          } else {
+          }
+          else {
             (Double.NegativeInfinity, '.')
           }
           val (ins, trIns) = if (i >= 1) {
-            val idx = (i-1) * stride + j
+            val idx = (i - 1) * stride + j
             val insMatch = matches(idx) + indelToMatchPrior
             val insInsert = inserts(idx) + indelToIndelPrior
             val insMax = max(insMatch, insInsert)
             val t = if (fpCompare(insMax, insMatch, 0.01)) {
               'M'
-            } else if (fpCompare(insMax, insInsert, 0.01)) {
+            }
+            else if (fpCompare(insMax, insInsert, 0.01)) {
               'I'
-            } else {
+            }
+            else {
               '.'
             }
             (insMax, t)
-          } else {
+          }
+          else {
             (Double.NegativeInfinity, '.')
           }
           val (del, trDel) = if (j >= 1) {
@@ -162,13 +171,16 @@ class HMMAligner {
             val delMax = max(delMatch, delDelete)
             val t = if (fpCompare(delMax, delMatch, 0.01)) {
               'M'
-            } else if (fpCompare(delMax, delDelete, 0.01)) {
+            }
+            else if (fpCompare(delMax, delDelete, 0.01)) {
               'D'
-            } else {
+            }
+            else {
               '.'
             }
             (delMax, t)
-          } else {
+          }
+          else {
             (Double.NegativeInfinity, '.')
           }
           val idx = i * stride + j
@@ -184,7 +196,8 @@ class HMMAligner {
 
     if (matSize > 0) {
       alignmentLikelihood = max(matches(matSize - 1), max(inserts(matSize - 1), deletes(matSize - 1)))
-    } else {
+    }
+    else {
       alignmentLikelihood = max(matches(0), max(inserts(0), deletes(0)))
     }
 
@@ -199,7 +212,7 @@ class HMMAligner {
         if (HMMAligner.debug) println(s)
       }
     }
-    
+
     if (HMMAligner.debug) {
       println("matches")
       printArray(matches)
@@ -220,11 +233,12 @@ class HMMAligner {
     def indexMax(a: (Double, Int), b: (Double, Int)): (Double, Int) = {
       if (a._1 > b._1) {
         a
-      } else {
+      }
+      else {
         b
       }
     }
-    
+
     def getArrayMax(array: Array[Double]): (Double, Int) = {
       array.zipWithIndex.reduce(indexMax)
     }
@@ -236,18 +250,18 @@ class HMMAligner {
 
     var i = paddedTestLen - 1
     var j = paddedRefLen - 1
-    
+
     if (HMMAligner.debug)
       println(i + ", " + j)
 
     while (i > 0 && j > 0) {
       val idx = i * stride + j
-      
+
       if (HMMAligner.debug) {
         println(i + ", " + j + (": %1.1f" format matches(idx)) + (", %1.1f" format inserts(idx)) +
-                (", %1.1f" format deletes(idx)))
+          (", %1.1f" format deletes(idx)))
       }
-              
+
       val bestScore = max(matches(idx), max(inserts(idx), deletes(idx)))
       // TODO(peter, 12/7) here, build the aligned sequences.
       val tr = if (fpCompare(bestScore, matches(idx), 0.0001)) {
@@ -263,21 +277,24 @@ class HMMAligner {
         }
         // FIXME
         traceMatches(idx)
-      } else if (fpCompare(bestScore, inserts(idx), 0.0001)) {
+      }
+      else if (fpCompare(bestScore, inserts(idx), 0.0001)) {
         revAlignedTestSeq += testSequence(i - 1)
         revAlignedRefSeq += '_'
         hasVariants = true
         numIndels += 1
         revAlignment += 'I'
         traceInserts(idx)
-      } else if (fpCompare(bestScore, deletes(idx), 0.0001)) {
+      }
+      else if (fpCompare(bestScore, deletes(idx), 0.0001)) {
         revAlignedRefSeq += refSequence(j - 1)
         revAlignedTestSeq += '_'
         hasVariants = true
         numIndels += 1
         revAlignment += 'D'
         traceDeletes(idx)
-      } else {
+      }
+      else {
         revAlignedTestSeq += 'x'
         revAlignedRefSeq += 'x'
         '.'
@@ -300,7 +317,7 @@ class HMMAligner {
         } // TODO(peter, 12/8) the alignment is bad (probably a bug).
       }
     }
-    
+
     testAligned = revAlignedTestSeq.reverse
     refAligned = revAlignedRefSeq.reverse
 
@@ -308,7 +325,7 @@ class HMMAligner {
       println("ta: " + testAligned)
       println("ra: " + refAligned)
     }
-      
+
     var unitAlignment = revAlignment.reverse
     if (HMMAligner.debug) println(unitAlignment)
     alignment = new ArrayBuffer[(Int, Char)]
@@ -344,21 +361,21 @@ class HMMAligner {
    *
    * @return Log10 likelihood of alignment.
    */
-  def getLikelihood (): Double = alignmentLikelihood
+  def getLikelihood(): Double = alignmentLikelihood
 
   /**
    * Compute the (log10) prior prob of observing the given alignment.
    *
    * @return Prior for alignment.
    */
-  def getPrior (): Double = alignmentPrior
+  def getPrior(): Double = alignmentPrior
 
   /**
    * Compute the alignment tokens (equivalent to cigar).
    *
    * @return Alignment tokens.
    */
-  def getAlignment (): ArrayBuffer[(Int, Char)] = {
+  def getAlignment(): ArrayBuffer[(Int, Char)] = {
     alignment.clone
   }
 
@@ -367,7 +384,7 @@ class HMMAligner {
    *
    * @return Tuple of sequences aligned to (ref, test) sequences.
    */
-  def getAlignedSequences (): (String, String) = (refAligned, testAligned)
+  def getAlignedSequences(): (String, String) = (refAligned, testAligned)
 }
 
 /**
@@ -375,12 +392,12 @@ class HMMAligner {
  *
  * @param sequence String representing haplotype alignment.
  */
-class Haplotype (val sequence: String) {
+class Haplotype(val sequence: String) {
   var perReadLikelihoods = new ArrayBuffer[Double]
   var readsLikelihood = Double.NegativeInfinity
   var hasVariants = false
   var alignment = new ArrayBuffer[(Int, Char)]
-  
+
   /**
    * Score likelihood of reads when assembled into haplotype.
    *
@@ -388,7 +405,7 @@ class Haplotype (val sequence: String) {
    * @param reads Sequence of reads to use.
    * @return Likelihood that reads are properly aligned.
    */
-  def scoreReadsLikelihood (hmm: HMMAligner, reads: Seq[ADAMRecord]): Double = {
+  def scoreReadsLikelihood(hmm: HMMAligner, reads: Seq[ADAMRecord]): Double = {
     perReadLikelihoods.clear
     readsLikelihood = 0.0
     for (r <- reads) {
@@ -398,8 +415,9 @@ class Haplotype (val sequence: String) {
         val readLike = hmm.getLikelihood // - hmm.getPriora
         perReadLikelihoods += readLike
         readsLikelihood += readLike
-      } catch {
-        case _ : Throwable => {
+      }
+      catch {
+        case _: Throwable => {
           perReadLikelihoods += 0.0
           readsLikelihood += 0.0
         }
@@ -415,7 +433,7 @@ class Haplotype (val sequence: String) {
    * @param refHaplotype Haplotype for reference in this location.
    * @return True if region has variants.
    */
-  def alignToReference (hmm: HMMAligner, refHaplotype: Haplotype): Boolean = {
+  def alignToReference(hmm: HMMAligner, refHaplotype: Haplotype): Boolean = {
     // TODO(peter, 12/8) store the alignment details (including the cigar).
     hasVariants = hmm.alignSequences(refHaplotype.sequence, sequence, null)
     alignment = hmm.getAlignment
@@ -441,12 +459,14 @@ object HaplotypeOrdering extends Ordering[Haplotype] {
    * @param h2 Second haplotype to compare.
    * @return Ordering info for haplotypes.
    */
-  def compare (h1: Haplotype, h2: Haplotype): Int = {
+  def compare(h1: Haplotype, h2: Haplotype): Int = {
     if (h1.readsLikelihood < h2.readsLikelihood) {
       -1
-    } else if (h1.readsLikelihood > h2.readsLikelihood) {
+    }
+    else if (h1.readsLikelihood > h2.readsLikelihood) {
       1
-    } else {
+    }
+    else {
       0
     }
   }
@@ -458,7 +478,7 @@ object HaplotypeOrdering extends Ordering[Haplotype] {
  * @param haplotype1 First haplotype of pair.
  * @param haplotype2 Second haplotype of pair.
  */
-class HaplotypePair (val haplotype1: Haplotype, val haplotype2: Haplotype) {
+class HaplotypePair(val haplotype1: Haplotype, val haplotype2: Haplotype) {
   var pairLikelihood = Double.NegativeInfinity
   var hasVariants = false
 
@@ -475,7 +495,7 @@ class HaplotypePair (val haplotype1: Haplotype, val haplotype2: Haplotype) {
    *
    * @see approxLogSumExp10
    */
-  def exactLogSumExp10 (x1: Double, x2: Double): Double = {
+  def exactLogSumExp10(x1: Double, x2: Double): Double = {
     log10(pow(10.0, x1) + pow(10.0, x2))
   }
 
@@ -488,7 +508,7 @@ class HaplotypePair (val haplotype1: Haplotype, val haplotype2: Haplotype) {
    *
    * @see exactLogSumExp10
    */
-  def approxLogSumExp10 (x1: Double, x2: Double): Double = {
+  def approxLogSumExp10(x1: Double, x2: Double): Double = {
     exactLogSumExp10(x1, x2)
   }
 
@@ -499,7 +519,7 @@ class HaplotypePair (val haplotype1: Haplotype, val haplotype2: Haplotype) {
    * @param reads Sequence of reads that are evidence for haplotype.
    * @return Phred scaled likelihood.
    */
-  def scorePairLikelihood (hmm: HMMAligner, reads: Seq[ADAMRecord]): Double = {
+  def scorePairLikelihood(hmm: HMMAligner, reads: Seq[ADAMRecord]): Double = {
     var readsProb = 0.0
     for (i <- 0 until reads.length) {
       val readLikelihood1 = haplotype1.perReadLikelihoods(i)
@@ -519,7 +539,7 @@ class HaplotypePair (val haplotype1: Haplotype, val haplotype2: Haplotype) {
    * @param refHaplotype Reference haplotype for active region.
    * @return True if region has variants.
    */
-  def alignToReference (hmm: HMMAligner, refHaplotype: Haplotype): Boolean = {
+  def alignToReference(hmm: HMMAligner, refHaplotype: Haplotype): Boolean = {
     hasVariants = haplotype1.alignToReference(hmm, refHaplotype)
     if (haplotype2 != haplotype1) {
       hasVariants |= haplotype2.alignToReference(hmm, refHaplotype)
@@ -542,12 +562,14 @@ object HaplotypePairOrdering extends Ordering[HaplotypePair] {
    * @param pair2 Second haplotype pair to compare.
    * @return Comparison of haplotype pairs.
    */
-  def compare (pair1: HaplotypePair, pair2: HaplotypePair): Int = {
+  def compare(pair1: HaplotypePair, pair2: HaplotypePair): Int = {
     if (pair1.pairLikelihood < pair2.pairLikelihood) {
       -1
-    } else if (pair1.pairLikelihood > pair2.pairLikelihood) {
+    }
+    else if (pair1.pairLikelihood > pair2.pairLikelihood) {
       1
-    } else {
+    }
+    else {
       0
     }
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/VariantCall.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/VariantCall.scala
@@ -14,54 +14,54 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls
+package org.bdgenomics.avocado.calls
 
-import org.apache.commons.configuration.{HierarchicalConfiguration, SubnodeConfiguration}
+import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{SparkContext, Logging}
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMPileup, ADAMVariant, ADAMGenotype}
-import edu.berkeley.cs.amplab.adam.converters.GenotypesToVariantsConverter
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.apache.spark.{ SparkContext, Logging }
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMPileup, ADAMVariant, ADAMGenotype }
+import org.bdgenomics.adam.converters.GenotypesToVariantsConverter
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 trait VariantCallCompanion {
 
   val callName: String
-  
-  protected def apply (stats: AvocadoConfigAndStats, config: SubnodeConfiguration): VariantCall
 
-  final def apply (stats: AvocadoConfigAndStats,
-                   globalConfig: HierarchicalConfiguration, 
-                   callSetName: String): VariantCall = {
+  protected def apply(stats: AvocadoConfigAndStats, config: SubnodeConfiguration): VariantCall
+
+  final def apply(stats: AvocadoConfigAndStats,
+                  globalConfig: HierarchicalConfiguration,
+                  callSetName: String): VariantCall = {
     val config: SubnodeConfiguration = globalConfig.configurationAt(callSetName)
-    
-    apply (stats, config)
+
+    apply(stats, config)
   }
-  
+
 }
 
 /**
- * Abstract class for calling variants on reads. 
+ * Abstract class for calling variants on reads.
  */
 abstract class VariantCall extends Serializable with Logging {
 
   val companion: VariantCallCompanion
 
-  def process (rdd: RDD[ADAMRecord]): RDD[ADAMRecord] = {
+  def process(rdd: RDD[ADAMRecord]): RDD[ADAMRecord] = {
     var readsToProcess = rdd.cache
 
     readsToProcess
   }
 
-  def processAndCall (rdd: RDD[ADAMRecord]): RDD[ADAMVariantContext] = {
+  def processAndCall(rdd: RDD[ADAMRecord]): RDD[ADAMVariantContext] = {
     val processedReads = process(rdd)
     call(rdd)
   }
 
   final def genotypesToVariantContext(genotypes: List[ADAMGenotype],
                                       samples: Int = 1): List[ADAMVariantContext] = {
-    
+
     val grouped = genotypes.groupBy(
       g => (g.getVariant.getContig.getContigId, g.getVariant.getVariantAllele))
       .map(kv => {
@@ -69,14 +69,14 @@ abstract class VariantCall extends Serializable with Logging {
 
         ADAMVariantContext.buildFromGenotypes(g)
       })
-    
+
     grouped.toList
   }
 
-  def call (rdd: RDD[ADAMRecord]): RDD[ADAMVariantContext]
+  def call(rdd: RDD[ADAMRecord]): RDD[ADAMVariantContext]
 
-  def isReadCall (): Boolean
-  def isPileupCall (): Boolean
-  def isCallable (): Boolean
+  def isReadCall(): Boolean
+  def isPileupCall(): Boolean
+  def isCallable(): Boolean
 }
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/VariantCaller.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/VariantCaller.scala
@@ -14,29 +14,29 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls
+package org.bdgenomics.avocado.calls
 
-import org.apache.commons.configuration.{HierarchicalConfiguration, SubnodeConfiguration}
+import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMPileup, ADAMVariant, ADAMGenotype}
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
-import edu.berkeley.cs.amplab.avocado.calls.pileup.{PileupCallSimpleSNP, PileupCallUnspecified}
-import edu.berkeley.cs.amplab.avocado.calls.reads.{ReadCallAssemblyPhaser, ReadCallUnspecified}
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMPileup, ADAMVariant, ADAMGenotype }
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.avocado.calls.pileup.{ PileupCallSimpleSNP, PileupCallUnspecified }
+import org.bdgenomics.avocado.calls.reads.{ ReadCallAssemblyPhaser, ReadCallUnspecified }
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 object VariantCaller {
 
   private val calls = List(PileupCallSimpleSNP,
-                           PileupCallUnspecified,
-                           ReadCallAssemblyPhaser,
-                           ReadCallUnspecified)
+    PileupCallUnspecified,
+    ReadCallAssemblyPhaser,
+    ReadCallUnspecified)
 
-  def apply (callName: String,
-             callAlgorithm: String, 
-             stats: AvocadoConfigAndStats, 
-             config: HierarchicalConfiguration): VariantCall = {
-    val call = calls.find (_.callName == callAlgorithm)
+  def apply(callName: String,
+            callAlgorithm: String,
+            stats: AvocadoConfigAndStats,
+            config: HierarchicalConfiguration): VariantCall = {
+    val call = calls.find(_.callName == callAlgorithm)
 
     call match {
       case Some(c) => {

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/EMforAlleles.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/EMforAlleles.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.pileup
+package org.bdgenomics.avocado.calls.pileup
 
 import scala.math.pow
 
@@ -26,7 +26,7 @@ object EMForAlleles {
    *      GL - Array of arrays of likelihood triples P( D | g )
    *          (note these are NOT multiplied by P(g | phi)! )
    *  OUT: Phi - ML estimate of MAF's across SNPs
-   * 
+   *
    *  Note: GL is currently an array of (numSnps) arrays of length (numInds),
    */
   def emForMAF(Phi: Array[Double], GL: Array[Array[(Double, Double, Double)]]): Array[Double] = {
@@ -34,16 +34,14 @@ object EMForAlleles {
     val tol = 0.0001
     val L = Phi.length
     var phi_updates = Phi
-    while( eps > tol ){
-      var Phi_next = Array.fill(L){0.0}
+    while (eps > tol) {
+      var Phi_next = Array.fill(L) { 0.0 }
       Phi_next.indices.foreach(i => {
         GL(i).foreach(l => {
           Phi_next(i) += (1.0 / (2.0 * GL(i).length)) * ((1.0 * l._2 * 2.0 * phi_updates(i) * (1 - phi_updates(i)) +
-                                                          2.0 * l._3 * pow(phi_updates(i), 2.0)) / (l._1 * pow(1.0 - phi_updates(i), 2.0) +
-                                                                                                    l._2 * 2.0 * phi_updates(i) * (1.0 - phi_updates(i)) +
-                                                                                                    l._3 * pow(phi_updates(i), 2.0)
-                                                                                                  )
-                                                       )
+            2.0 * l._3 * pow(phi_updates(i), 2.0)) / (l._1 * pow(1.0 - phi_updates(i), 2.0) +
+              l._2 * 2.0 * phi_updates(i) * (1.0 - phi_updates(i)) +
+              l._3 * pow(phi_updates(i), 2.0)))
         })
       })
       var eps = 0.0
@@ -52,42 +50,45 @@ object EMForAlleles {
     }
     return phi_updates
   }
-  
+
   /**
    * Helper function to compute Y iteratively
    * For each site, executes the recursion in 4.2.3. Y(i) is Ynk vector for site i
    */
-  def compY(GL: Array[Array[(Double,Double,Double)]]): Array[Array[Double]] = {
+  def compY(GL: Array[Array[(Double, Double, Double)]]): Array[Array[Double]] = {
     val L = GL.length
     val GLt = GL.transpose
     val n = GLt.length
     val M = 2 * n
     var Y = Array.ofDim[Double](L, n + 1, M + 1)
     // NOTE: this ordering may be suboptimal?
-    for(i <- 0 until L){
-      for(k <- 0 to M){
-        for(j <- 0 to n){ // 0 = 0 people not first person
-          if(j == 0) {
+    for (i <- 0 until L) {
+      for (k <- 0 to M) {
+        for (j <- 0 to n) { // 0 = 0 people not first person
+          if (j == 0) {
             Y(i)(j)(k) = 1.0
-          } else if(k == 0) {
+          }
+          else if (k == 0) {
             Y(i)(j)(k) = (1.0 / (2.0 * j * (2.0 * j - 1.0))) * ((2.0 * j - k) * (2.0 * j - k - 1.0) * Y(i)(j - 1)(k) * GL(i)(j)._1)
-          } else if(k == 1) {
-            Y(i)(j)(k) = (1.0 / (2.0 * j * (2.0 * j - 1.0))) * ((2.0 * j - k) * (2.0 * j - k - 1.0) * Y(i)(j - 1)(k) * GL(i)(j)._1 + 
-                                                                2.0 * k * (2.0 * j - k) * Y(i)(j - 1)(k - 1) * GL(i)(j)._2)
-          } else {
+          }
+          else if (k == 1) {
             Y(i)(j)(k) = (1.0 / (2.0 * j * (2.0 * j - 1.0))) * ((2.0 * j - k) * (2.0 * j - k - 1.0) * Y(i)(j - 1)(k) * GL(i)(j)._1 +
-                                                                2.0 * k * (2.0 * j - k) * Y(i)(j - 1)(k - 1) * GL(i)(j)._2 + k * (k - 1.0) *
-                                                                Y(i)(j - 1)(k - 2) * GL(i)(j)._2)
+              2.0 * k * (2.0 * j - k) * Y(i)(j - 1)(k - 1) * GL(i)(j)._2)
+          }
+          else {
+            Y(i)(j)(k) = (1.0 / (2.0 * j * (2.0 * j - 1.0))) * ((2.0 * j - k) * (2.0 * j - k - 1.0) * Y(i)(j - 1)(k) * GL(i)(j)._1 +
+              2.0 * k * (2.0 * j - k) * Y(i)(j - 1)(k - 1) * GL(i)(j)._2 + k * (k - 1.0) *
+              Y(i)(j - 1)(k - 2) * GL(i)(j)._2)
           }
         }
       }
     }
-    
+
     var Yr = Array.ofDim[Double](L, M)
-    for(l <- 0 until L) Yr(l) = Y(l)(n)
+    for (l <- 0 until L) Yr(l) = Y(l)(n)
     return Yr
   }
-  
+
   /**
    * Main AFS EM function
    *   IN: Phi - an initial MAF vector of length number of SNPs
@@ -96,23 +97,23 @@ object EMForAlleles {
    *   OUT: Phi - ML estimate of MAF's across SNPs
    *   Note: GL is currently an array of (numSnps) arrays of length (numInds), which is transposed
    */
-  def emForAFS( Phik: Array[Double], GL: Array[Array[(Double, Double, Double)]]): Array[Double] = {
+  def emForAFS(Phik: Array[Double], GL: Array[Array[(Double, Double, Double)]]): Array[Double] = {
     val GLt = GL.transpose
     val tol = 0.0001
     val L = GL.length
     val M = Phik.length
     var eps = 1.0
-    var Y = compY( GL )
+    var Y = compY(GL)
     var phik_updates = Phik
-    while(eps > tol) {
-      var sums = Array.fill(L){0.0}
+    while (eps > tol) {
+      var sums = Array.fill(L) { 0.0 }
       sums.indices.foreach(a => phik_updates.indices.foreach(p => sums(a) += phik_updates(p) * Y(a)(p)))
-      val Phik_next = Array.fill(M){0.0}
+      val Phik_next = Array.fill(M) { 0.0 }
       Phik_next.indices.foreach(i => Y.foreach(y => Phik_next(i) += (1.0 / L) * phik_updates(i) * y(i) / sums(i)))
       eps = 0.0
       phik_updates.indices.foreach(i => eps += pow(phik_updates(i) - Phik_next(i), 2.0))
       phik_updates = Phik_next
     }
     phik_updates
-  } 
+  }
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/MPileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/MPileupCallSimpleSNP.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.pileup
+package org.bdgenomics.avocado.calls.pileup
 
-import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMGenotype, ADAMPileup}
-import edu.berkeley.cs.amplab.adam.models.{ADAMRod, ADAMVariantContext}
-import edu.berkeley.cs.amplab.avocado.calls.VariantCallCompanion
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.{ Base, ADAMGenotype, ADAMPileup }
+import org.bdgenomics.adam.models.{ ADAMRod, ADAMVariantContext }
+import org.bdgenomics.avocado.calls.VariantCallCompanion
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
@@ -31,8 +31,8 @@ object MPileupCallSimpleSNP extends VariantCallCompanion {
 
   val callName = "MultipleSamplesSimpleSNP"
 
-  def apply (stats: AvocadoConfigAndStats,
-             config: SubnodeConfiguration): PileupCallSimpleSNP = {
+  def apply(stats: AvocadoConfigAndStats,
+            config: SubnodeConfiguration): PileupCallSimpleSNP = {
 
     val ploidy = config.getInt("ploidy", 2)
     val minorAlleleFrequency = config.getDouble("minorAlleleFrequency", 0.1)
@@ -50,8 +50,8 @@ object MPileupCallSimpleSNP extends VariantCallCompanion {
  * for multiple samples. At the current point in time, we assume that we are running on a diploid organism,
  * and that all sites are biallelic.
  */
-class MPileupCallSimpleSNP (ploidy: Int, 
-                            minorAlleleFrequency: Double) extends PileupCallSimpleSNP(ploidy) {
+class MPileupCallSimpleSNP(ploidy: Int,
+                           minorAlleleFrequency: Double) extends PileupCallSimpleSNP(ploidy) {
 
   override val companion = MPileupCallSimpleSNP
 
@@ -59,11 +59,11 @@ class MPileupCallSimpleSNP (ploidy: Int,
    * Calls a SNP for a single pileup, if there is sufficient evidence of a mismatch from the reference.
    * Takes in a single pileup rod from a single sample at a single locus. For simplicity, we assume that
    * all sites are biallelic.
-   * 
+   *
    * @param[in] pileup List of pileups. Should only contain one rod.
    * @return List of variants seen at site. List can contain 0 or 1 elements - value goes to flatMap.
    */
-  protected def callSNP (pileup: ADAMRod): List[ADAMVariantContext] = {
+  protected def callSNP(pileup: ADAMRod): List[ADAMVariantContext] = {
     val samples = pileup.splitBySamples
 
     // score off of rod info
@@ -71,16 +71,16 @@ class MPileupCallSimpleSNP (ploidy: Int,
       .map(scoreGenotypeLikelihoods)
       .map(v => Array((v(0), v(1), v(2))))
       .toArray
-      
+
     // run maf EM
     val majAlleleFrequency = EMForAlleles.emForMAF(Array(1.0 - minorAlleleFrequency),
-                                                   likelihoods)
+      likelihoods)
 
-    def compensate (likelihood: Array[(Double, Double, Double)], maf: Double): List[Double] = {
+    def compensate(likelihood: Array[(Double, Double, Double)], maf: Double): List[Double] = {
       // compensate likelihoods by major allele frequency - eqn 19 from source
       List(likelihood(0)._1 * pow(maf, 2.0),
-           likelihood(0)._2 * 2.0 * maf * (1.0 - maf),
-           likelihood(0)._3 * pow((1.0 - maf), 2.0))
+        likelihood(0)._2 * 2.0 * maf * (1.0 - maf),
+        likelihood(0)._3 * pow((1.0 - maf), 2.0))
     }
 
     // compensate genotypes by maf
@@ -88,23 +88,22 @@ class MPileupCallSimpleSNP (ploidy: Int,
 
     // genotype/variant lists
     var g = List[ADAMGenotype]()
-    
+
     // get most often seen non-reference base
     val maxNonRefBase = getMaxNonRefBase(pileup.pileups)
-    
+
     // loop over samples and write calls to list
     for (i <- 0 until likelihoods.length) {
       val l = compensatedLikelihoods(i)
 
       val sg: List[ADAMGenotype] = writeCallInfo(samples(i).pileups.head, l, maxNonRefBase)
-    
+
       g = g ::: sg
     }
 
     genotypesToVariantContext(g, samples.length)
   }
 
-  override def isCallable (): Boolean = true
+  override def isCallable(): Boolean = true
 }
-
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCall.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCall.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.pileup
+package org.bdgenomics.avocado.calls.pileup
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
-import edu.berkeley.cs.amplab.adam.rdd.AdamRDDFunctions
-import edu.berkeley.cs.amplab.adam.models.{ADAMRod, ADAMVariantContext}
-import edu.berkeley.cs.amplab.avocado.calls.VariantCall
-import edu.berkeley.cs.amplab.avocado.Avocado
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMRDDFunctions
+import org.bdgenomics.adam.models.{ ADAMRod, ADAMVariantContext }
+import org.bdgenomics.avocado.calls.VariantCall
+import org.bdgenomics.avocado.Avocado
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{SparkContext, Logging}
+import org.apache.spark.{ SparkContext, Logging }
 
 /**
- * Abstract class for calling variants on reads. 
+ * Abstract class for calling variants on reads.
  */
 abstract class PileupCall extends VariantCall {
 
@@ -36,7 +36,7 @@ abstract class PileupCall extends VariantCall {
    * @param pileups An RDD of pileups.
    * @return An RDD containing called variants.
    */
-  def callRods (pileups: RDD[ADAMRod]): RDD[ADAMVariantContext]
+  def callRods(pileups: RDD[ADAMRod]): RDD[ADAMVariantContext]
 
   /**
    * Converts reads to rods, then calls rod based variant caller.
@@ -44,11 +44,11 @@ abstract class PileupCall extends VariantCall {
    * @param reads An RDD of reads.
    * @return An RDD containing called variants.
    */
-  def call (reads: RDD[ADAMRecord]): RDD[ADAMVariantContext] = {
+  def call(reads: RDD[ADAMRecord]): RDD[ADAMVariantContext] = {
     val rods = reads.adamRecords2Rods()
     callRods(rods)
   }
-  
-  override def isReadCall (): Boolean = false
-  override def isPileupCall (): Boolean = true
+
+  override def isReadCall(): Boolean = false
+  override def isPileupCall(): Boolean = true
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSNP.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.pileup
+package org.bdgenomics.avocado.calls.pileup
 
-import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMContig, ADAMGenotype, ADAMPileup, ADAMVariant}
-import edu.berkeley.cs.amplab.adam.models.{ADAMRod, ADAMVariantContext}
-import edu.berkeley.cs.amplab.adam.util.PhredUtils
-import edu.berkeley.cs.amplab.avocado.calls.VariantCallCompanion
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.{ Base, ADAMContig, ADAMGenotype, ADAMPileup, ADAMVariant }
+import org.bdgenomics.adam.models.{ ADAMRod, ADAMVariantContext }
+import org.bdgenomics.adam.util.PhredUtils
+import org.bdgenomics.avocado.calls.VariantCallCompanion
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
@@ -31,8 +31,8 @@ object PileupCallSimpleSNP extends VariantCallCompanion {
 
   val callName = "SimpleSNP"
 
-  def apply (stats: AvocadoConfigAndStats,
-             config: SubnodeConfiguration): PileupCallSimpleSNP = {
+  def apply(stats: AvocadoConfigAndStats,
+            config: SubnodeConfiguration): PileupCallSimpleSNP = {
 
     val ploidy = config.getInt("ploidy", 2)
 
@@ -50,8 +50,8 @@ object PileupCallSimpleSNP extends VariantCallCompanion {
  * We only call the genotype if the likelihood has a phred score greater than or equal to 30.
  * At the current point in time, we assume that we are running on a diploid organism.
  */
-class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
-  
+class PileupCallSimpleSNP(ploidy: Int) extends PileupCall {
+
   val companion: VariantCallCompanion = PileupCallSimpleSNP
 
   /**
@@ -65,9 +65,9 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
    * @param maxNonRefBase Highest likelihood base for mismatch.
    * @return List of variants called, with 0 (homozygous reference) or 1 entry.
    */
-  protected def writeCallInfo (pileupHead: ADAMPileup, 
-                               likelihood: List[Double], 
-                               maxNonRefBase: Option[Base]): List[ADAMGenotype] = {
+  protected def writeCallInfo(pileupHead: ADAMPileup,
+                              likelihood: List[Double],
+                              maxNonRefBase: Option[Base]): List[ADAMGenotype] = {
     assert(likelihood.length == 3)
 
     // get phred scores
@@ -77,16 +77,17 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
 
     // simplifying assumption - snps are biallelic
     val call = if (likelihood.indexOf(likelihood.max) != 0 &&
-                   maxNonRefBase.isEmpty) {
+      maxNonRefBase.isEmpty) {
       // genotype likelihood is not in favor of reference, but we do not have any non ref bases?
       log.warn("Want to call non-homozygous ref genotype, but don't see non-ref bases @ " +
-               pileupHead.getPosition + ".")
-      List[ADAMGenotype]()      
-    } else if (likelihood.indexOf(likelihood.max) == 1) {
+        pileupHead.getPosition + ".")
+      List[ADAMGenotype]()
+    }
+    else if (likelihood.indexOf(likelihood.max) == 1) {
       // hetereozygous
       assert(pileupHead.getReferenceBase != maxNonRefBase.get,
-             "Cannot have reference be equal to non-ref base, @ " + pileupHead.getPosition + ".")
-      
+        "Cannot have reference be equal to non-ref base, @ " + pileupHead.getPosition + ".")
+
       val contig = ADAMContig.newBuilder
         .setContigId(pileupHead.getReferenceId)
         .setContigName(pileupHead.getReferenceName)
@@ -111,11 +112,12 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
         .build()
 
       List(genotypeRef, genotypeNonRef)
-    } else if (likelihood.indexOf(likelihood.max) == 2) {
+    }
+    else if (likelihood.indexOf(likelihood.max) == 2) {
       // homozygous non reference
       assert(pileupHead.getReferenceBase != maxNonRefBase.get,
-             "Cannot have reference be equal to non-ref base, @ " + pileupHead.getPosition + ".")
-            
+        "Cannot have reference be equal to non-ref base, @ " + pileupHead.getPosition + ".")
+
       val contig = ADAMContig.newBuilder
         .setContigId(pileupHead.getReferenceId)
         .setContigName(pileupHead.getReferenceName)
@@ -131,16 +133,17 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
         .setSampleId(pileupHead.getRecordGroupSample)
         .setGenotypeQuality(homozygousNonPhred)
         .setExpectedAlleleDosage(2.0f)
-	.build()
+        .build()
       val genotypeNonRef1 = ADAMGenotype.newBuilder()
         .setVariant(variant)
         .setSampleId(pileupHead.getRecordGroupSample)
         .setGenotypeQuality(homozygousNonPhred)
         .setExpectedAlleleDosage(2.0f)
-	.build()
+        .build()
 
       List(genotypeNonRef0, genotypeNonRef1)
-    } else {
+    }
+    else {
       // homozygous
       List[ADAMGenotype]()
     }
@@ -158,7 +161,7 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
    * @param[in] pileup Rod containing pileup bases.
    * @return List of doubles corresponding to likelihood of homozygous (2), heterozygous (1), and homozygous non-reference (0).
    */
-  def scoreGenotypeLikelihoods (pileup: List[ADAMPileup]): List[Double] = {
+  def scoreGenotypeLikelihoods(pileup: List[ADAMPileup]): List[Double] = {
 
     // count bases in pileup
     val k = pileup.map(_.getCountAtPosition).reduce(_ + _)
@@ -183,12 +186,11 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
     val mismatchBases = pileup.filter(v => {
       val readBase = Option(v.getReadBase) match {
         case Some(base) => base
-        case None => Base.N // TODO: add better exception handling code - this case shouldn't happen unless there is deletion evidence in the rod
+        case None       => Base.N // TODO: add better exception handling code - this case shouldn't happen unless there is deletion evidence in the rod
       }
 
       ((readBase != v.getReferenceBase) && (v.getRangeLength == 0 || v.getRangeLength == null))
     })
-
 
     val likelihoods = states.map(g => {
       // contribution of bases that match the reference
@@ -198,18 +200,20 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
 
           pow((ploidy - g) * epsilon + g * (1 - epsilon), base.getCountAtPosition.toDouble)
         }).reduce(_ * _)
-      } else {
+      }
+      else {
         1.0
       }
 
       // contribution of bases that do not match the base
       val productMismatch = if (mismatchBases.length != 0) {
         mismatchBases.map((base) => {
-          val epsilon =  PhredUtils.phredToErrorProbability((base.getMapQuality + base.getSangerQuality) / 2)
+          val epsilon = PhredUtils.phredToErrorProbability((base.getMapQuality + base.getSangerQuality) / 2)
 
           pow((ploidy - g) * (1 - epsilon) + g * epsilon, base.getCountAtPosition.toDouble)
         }).reduce(_ * _)
-      } else {
+      }
+      else {
         1.0
       }
 
@@ -241,22 +245,24 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
      * @param[in] kv2 Key/value pair containing a Base and it's count.
      * @return The key/value pair with the higher count.
      */
-    def pickMaxBase (kv1: (Base, Int), kv2: (Base, Int)): (Base, Int) = {
+    def pickMaxBase(kv1: (Base, Int), kv2: (Base, Int)): (Base, Int) = {
       if (kv1._2 > kv2._2) {
         kv1
-      } else {
+      }
+      else {
         kv2
       }
     }
-    
+
     // reduce down to get the base with the highest count
-    if (nonRefBaseCount.isEmpty){
+    if (nonRefBaseCount.isEmpty) {
       None
-    } else {
+    }
+    else {
       Some(nonRefBaseCount.reduce(pickMaxBase)._1)
     }
   }
-  
+
   /**
    * Compensates likelihoods.
    *
@@ -272,28 +278,29 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
    * Calls a SNP for a single pileup, if there is sufficient evidence of a mismatch from the reference.
    * Takes in a single pileup rod from a single sample at a single locus. For simplicity, we assume that
    * all sites are biallelic.
-   * 
+   *
    * @param[in] pileup List of pileups. Should only contain one rod.
    * @return List of variants seen at site. List can contain 0 or 1 elements - value goes to flatMap.
    */
-  protected def callSNP (pileup: List[ADAMPileup]): List[ADAMVariantContext] = {
-    
+  protected def callSNP(pileup: List[ADAMPileup]): List[ADAMVariantContext] = {
+
     if (pileup.forall(_.getRangeLength == null)) {
       val loci = pileup.head.getPosition
       log.info("Calling pileup at " + loci)
-      
+
       // score off of rod info
       val likelihood = scoreGenotypeLikelihoods(pileup)
-    
+
       // compensate
       val compensatedLikelihood = compensate(likelihood, pileup)
 
       // get most often seen non-reference base
       val maxNonRefBase = getMaxNonRefBase(pileup)
-      
+
       // write calls to list
       genotypesToVariantContext(writeCallInfo(pileup.head, likelihood, maxNonRefBase))
-    } else {
+    }
+    else {
       // cannot call indels
       log.warn("Saw indel evidence at " + pileup.head.getPosition + ". Ignored.")
       List[ADAMVariantContext]()
@@ -306,14 +313,13 @@ class PileupCallSimpleSNP (ploidy: Int) extends PileupCall {
    * @param[in] pileupGroups An RDD containing lists of pileups.
    * @return An RDD containing called variants.
    */
-  override def callRods (pileups: RDD [ADAMRod]): RDD [ADAMVariantContext] = {
+  override def callRods(pileups: RDD[ADAMRod]): RDD[ADAMVariantContext] = {
     log.info("Calling SNPs on pileups and flattening.")
     pileups.map(_.pileups)
       .map(callSNP)
       .flatMap((p: List[ADAMVariantContext]) => p)
   }
 
-  override def isCallable (): Boolean = true
+  override def isCallable(): Boolean = true
 }
-
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallUnspecified.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallUnspecified.scala
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.pileup
+package org.bdgenomics.avocado.calls.pileup
 
-import edu.berkeley.cs.amplab.adam.models.{ADAMRod, ADAMVariantContext}
-import edu.berkeley.cs.amplab.avocado.calls.VariantCallCompanion
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.models.{ ADAMRod, ADAMVariantContext }
+import org.bdgenomics.avocado.calls.VariantCallCompanion
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 import org.apache.commons.configuration.SubnodeConfiguration
-import org.apache.spark.{SparkContext, Logging}
+import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
 
 object PileupCallUnspecified extends VariantCallCompanion {
 
   val callName = "PileupUnspecified"
 
-  def apply (stats: AvocadoConfigAndStats,
-             config: SubnodeConfiguration): PileupCallUnspecified = {
+  def apply(stats: AvocadoConfigAndStats,
+            config: SubnodeConfiguration): PileupCallUnspecified = {
 
     new PileupCallUnspecified()
   }
@@ -41,14 +41,14 @@ object PileupCallUnspecified extends VariantCallCompanion {
 class PileupCallUnspecified extends PileupCall {
 
   val companion = PileupCallUnspecified
- 
+
   /**
    * Empty calling method.
    */
-  override def callRods (pileups: RDD [ADAMRod]): RDD [ADAMVariantContext] = {
-    throw new IllegalArgumentException (companion.callName + " is not callable.")
+  override def callRods(pileups: RDD[ADAMRod]): RDD[ADAMVariantContext] = {
+    throw new IllegalArgumentException(companion.callName + " is not callable.")
   }
 
   // Call is generic, so is not callable
-  override def isCallable () = false
+  override def isCallable() = false
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCall.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCall.scala
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.reads
+package org.bdgenomics.avocado.calls.reads
 
-import edu.berkeley.cs.amplab.avocado.calls.VariantCall
-import org.apache.spark.{SparkContext, Logging}
+import org.bdgenomics.avocado.calls.VariantCall
+import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.models.ADAMVariantContext
 
 /**
- * Abstract class for calling variants on reads. 
+ * Abstract class for calling variants on reads.
  */
 abstract class ReadCall extends VariantCall {
 
@@ -33,9 +33,9 @@ abstract class ReadCall extends VariantCall {
    * @param[in] pileupGroups An RDD containing reads.
    * @return An RDD containing called variants.
    */
-  def call (pileupGroups: RDD [ADAMRecord]): RDD [ADAMVariantContext]
+  def call(pileupGroups: RDD[ADAMRecord]): RDD[ADAMVariantContext]
 
-  override def isReadCall (): Boolean = true
-  override def isPileupCall (): Boolean = false
+  override def isReadCall(): Boolean = true
+  override def isPileupCall(): Boolean = false
 }
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallUnspecified.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/calls/reads/ReadCallUnspecified.scala
@@ -14,29 +14,29 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.reads
+package org.bdgenomics.avocado.calls.reads
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.avocado.calls.VariantCallCompanion
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.avocado.calls.VariantCallCompanion
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 import org.apache.commons.configuration.SubnodeConfiguration
-import org.apache.spark.{SparkContext, Logging}
+import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
 
 object ReadCallUnspecified extends VariantCallCompanion {
 
   val callName = "ReadUnspecified"
 
-  def apply (stats: AvocadoConfigAndStats,
-             config: SubnodeConfiguration): ReadCallUnspecified = {
+  def apply(stats: AvocadoConfigAndStats,
+            config: SubnodeConfiguration): ReadCallUnspecified = {
 
     new ReadCallUnspecified()
   }
 }
 
 /**
- * Abstract class for calling variants on reads. 
+ * Abstract class for calling variants on reads.
  */
 class ReadCallUnspecified extends ReadCall {
 
@@ -45,10 +45,10 @@ class ReadCallUnspecified extends ReadCall {
   /**
    * Empty calling method.
    */
-  def call (pileupGroups: RDD [ADAMRecord]): RDD [ADAMVariantContext] = {
-    throw new IllegalArgumentException (companion.callName + " is not callable.")
+  def call(pileupGroups: RDD[ADAMRecord]): RDD[ADAMVariantContext] = {
+    throw new IllegalArgumentException(companion.callName + " is not callable.")
   }
 
   // Call is generic, so is not callable
-  override def isCallable () = false
+  override def isCallable() = false
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/input/AlignedReadsInputStage.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/input/AlignedReadsInputStage.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.input
+package org.bdgenomics.avocado.input
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMNucleotideContigFragment}
-import edu.berkeley.cs.amplab.adam.predicates.LocusPredicate
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._ 
-import edu.berkeley.cs.amplab.adam.rdd.AdamRDDFunctions
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMNucleotideContigFragment }
+import org.bdgenomics.adam.predicates.LocusPredicate
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMRDDFunctions
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -36,11 +36,11 @@ private[input] object AlignedReadsInputStage extends InputStage {
    * @param reference RDD containing reference information.
    * @return Returns an RDD of ADAM reads.
    */
-  def apply (sc: SparkContext,
-             inputPath: String,
-             config: SubnodeConfiguration,
-             reference: RDD[ADAMNucleotideContigFragment]): RDD[ADAMRecord] = {
-    
+  def apply(sc: SparkContext,
+            inputPath: String,
+            config: SubnodeConfiguration,
+            reference: RDD[ADAMNucleotideContigFragment]): RDD[ADAMRecord] = {
+
     println("Loading reads in from " + inputPath)
 
     sc.adamLoad(inputPath, Some(classOf[LocusPredicate]))

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/input/Input.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/input/Input.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.input
+package org.bdgenomics.avocado.input
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMNucleotideContigFragment}
-import org.apache.commons.configuration.{HierarchicalConfiguration, SubnodeConfiguration}
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMNucleotideContigFragment }
+import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -36,19 +36,19 @@ object Input {
    * @param stats Global stat and configuration data.
    * @return Returns an RDD of read data.
    */
-  def apply (sc: SparkContext,
-             inputPath: String,
-             reference: RDD[ADAMNucleotideContigFragment],
-             config: HierarchicalConfiguration): RDD[ADAMRecord] = {
+  def apply(sc: SparkContext,
+            inputPath: String,
+            reference: RDD[ADAMNucleotideContigFragment],
+            config: HierarchicalConfiguration): RDD[ADAMRecord] = {
     // get input stage to use; if none is specified, default to input being aligned reads
     val stageName: String = config.getString("inputStage", "AlignedReads")
 
     val stage = stages.find(_.stageName == stageName)
-    
+
     stage match {
       case Some(s: InputStage) => {
         val stageConfig = config.configurationAt(stageName)
-        
+
         s.apply(sc, inputPath, stageConfig, reference)
       }
       case None => {

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/input/InputStage.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/input/InputStage.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.input
+package org.bdgenomics.avocado.input
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMNucleotideContigFragment}
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMNucleotideContigFragment }
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -33,9 +33,9 @@ private[input] trait InputStage {
    * @param reference RDD containing reference information.
    * @return Returns an RDD of ADAM reads.
    */
-  def apply (sc: SparkContext,
-             inputPath: String,
-             config: SubnodeConfiguration,
-             reference: RDD[ADAMNucleotideContigFragment]): RDD[ADAMRecord]
+  def apply(sc: SparkContext,
+            inputPath: String,
+            config: SubnodeConfiguration,
+            reference: RDD[ADAMNucleotideContigFragment]): RDD[ADAMRecord]
 
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/PartitionSet.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/PartitionSet.scala
@@ -14,34 +14,36 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.partitioners
+package org.bdgenomics.avocado.partitioners
 
-import edu.berkeley.cs.amplab.adam.models.ReferenceRegion
+import org.bdgenomics.adam.models.ReferenceRegion
 import scala.annotation.tailrec
-import scala.collection.immutable.{SortedMap, TreeSet, SortedSet}
+import scala.collection.immutable.{ SortedMap, TreeSet, SortedSet }
 
-class PartitionSet (protected val regionMapping: SortedMap[ReferenceRegion, Int]) extends Serializable {
+class PartitionSet(protected val regionMapping: SortedMap[ReferenceRegion, Int]) extends Serializable {
 
   /**
    * Merges a region into a sorted set of regions.
    *
    * @note Assumes that the region being merged in is ordered after all regions in the
    * current set of regions.
-   * 
+   *
    * @param set Sorted set of previously merged regions.
    * @param region Region to merge in to set.
    * @return New set with new region merged in.
    */
-  private def mergeRegions (set: TreeSet[ReferenceRegion],
-                            region: ReferenceRegion): TreeSet[ReferenceRegion] = {
+  private def mergeRegions(set: TreeSet[ReferenceRegion],
+                           region: ReferenceRegion): TreeSet[ReferenceRegion] = {
     if (set.isEmpty) {
       set + region
-    } else {
+    }
+    else {
       val t = set.last
-      
+
       if (t.overlaps(region) || t.isAdjacent(region)) {
         set.dropRight(1) + t.merge(region)
-      } else {
+      }
+      else {
         set + region
       }
     }
@@ -53,7 +55,7 @@ class PartitionSet (protected val regionMapping: SortedMap[ReferenceRegion, Int]
    * @param regions Input set of regions.
    * @return Sorted set with overlapping regions merged together.
    */
-  private def merge (regions: SortedSet[ReferenceRegion]): TreeSet[ReferenceRegion] = {
+  private def merge(regions: SortedSet[ReferenceRegion]): TreeSet[ReferenceRegion] = {
     regions.foldLeft(TreeSet[ReferenceRegion]())(mergeRegions)
   }
 
@@ -63,11 +65,11 @@ class PartitionSet (protected val regionMapping: SortedMap[ReferenceRegion, Int]
    * Returns a list of all integer partition mappings that a region overlaps with.
    *
    * @note Can be overridden if a more performant partition mapping function can be provided.
-   * 
+   *
    * @param region Region of interest.
    * @return List of all partition indexes that this region overlaps with.
    */
-  def getPartition (region: ReferenceRegion): List[Int] = {
+  def getPartition(region: ReferenceRegion): List[Int] = {
     regionMapping.filterKeys(_.overlaps(region))
       .values
       .toList
@@ -79,7 +81,7 @@ class PartitionSet (protected val regionMapping: SortedMap[ReferenceRegion, Int]
    * @param region Region of interest.
    * @return True if region overlaps with any region inside of this partition.
    */
-  def isInSet (region: ReferenceRegion): Boolean = {
+  def isInSet(region: ReferenceRegion): Boolean = {
     !mergedPartitions.filter(_.refId == region.refId)
       .forall(r => !(r.contains(region) || r.overlaps(region)))
   }
@@ -90,7 +92,7 @@ class PartitionSet (protected val regionMapping: SortedMap[ReferenceRegion, Int]
    * @param region Region of interest.
    * @return True if region is not wholly contained inside of this set.
    */
-  def isOutsideOfSet (region: ReferenceRegion): Boolean = {
+  def isOutsideOfSet(region: ReferenceRegion): Boolean = {
     mergedPartitions.filter(_.refId == region.refId)
       .forall(r => !r.contains(region))
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/Partitioner.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/Partitioner.scala
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.partitioners
+package org.bdgenomics.avocado.partitioners
 
-import org.apache.commons.configuration.{HierarchicalConfiguration, SubnodeConfiguration}
+import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 object Partitioner {
 
   val partitioners = List(DefaultPartitioner)
 
-  def apply (rdd: RDD[ADAMRecord],
-             globalConfig: HierarchicalConfiguration,
-             partitionName: String,
-             partitionerAlgorithm: String,
-             stats: AvocadoConfigAndStats): ReferencePartitioner = {
+  def apply(rdd: RDD[ADAMRecord],
+            globalConfig: HierarchicalConfiguration,
+            partitionName: String,
+            partitionerAlgorithm: String,
+            stats: AvocadoConfigAndStats): ReferencePartitioner = {
     val partitioner = partitioners.find(_.partitionerName == partitionerAlgorithm)
-    
+
     assert(partitioner.isDefined, "Could not find partitioner: " + partitionerAlgorithm)
     partitioner.get.apply(rdd, globalConfig, partitionName, stats)
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/ReferencePartitioner.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/partitioners/ReferencePartitioner.scala
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.partitioners
+package org.bdgenomics.avocado.partitioners
 
-import org.apache.commons.configuration.{HierarchicalConfiguration, SubnodeConfiguration}
+import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 trait ReferencePartitionerCompanion {
 
   val partitionerName: String
 
-  protected def apply (rdd: RDD[ADAMRecord], 
-                       subnodeConfiguration: SubnodeConfiguration,
-                       stats: AvocadoConfigAndStats): ReferencePartitioner 
+  protected def apply(rdd: RDD[ADAMRecord],
+                      subnodeConfiguration: SubnodeConfiguration,
+                      stats: AvocadoConfigAndStats): ReferencePartitioner
 
-  final def apply (rdd: RDD[ADAMRecord], 
-                   globalConfig: HierarchicalConfiguration,
-                   partitionName: String,
-                   stats: AvocadoConfigAndStats): ReferencePartitioner = {
-    
+  final def apply(rdd: RDD[ADAMRecord],
+                  globalConfig: HierarchicalConfiguration,
+                  partitionName: String,
+                  stats: AvocadoConfigAndStats): ReferencePartitioner = {
+
     val config: SubnodeConfiguration = globalConfig.configurationAt(partitionName)
 
     apply(rdd, config, stats)
@@ -42,9 +42,9 @@ trait ReferencePartitionerCompanion {
 }
 
 trait ReferencePartitioner {
-  
+
   val companion: ReferencePartitionerCompanion
 
-  def computePartitions (): PartitionSet
-  
+  def computePartitions(): PartitionSet
+
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/postprocessing/FilterStrandBias.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/postprocessing/FilterStrandBias.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.postprocessing
+package org.bdgenomics.avocado.postprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMGenotype
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.ADAMGenotype
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 private[postprocessing] object FilterStrandBias extends PostprocessingStage {
 
@@ -36,20 +36,20 @@ private[postprocessing] object FilterStrandBias extends PostprocessingStage {
    * @param config Config from which to pull config data.
    * @return A filtered RDD.
    */
-  def apply (rdd: RDD[ADAMVariantContext], 
-             stats: AvocadoConfigAndStats,
-             config: SubnodeConfiguration): RDD[ADAMVariantContext] = {
+  def apply(rdd: RDD[ADAMVariantContext],
+            stats: AvocadoConfigAndStats,
+            config: SubnodeConfiguration): RDD[ADAMVariantContext] = {
 
     val high = config.getDouble("highLimit", 0.75)
     val low = config.getDouble("lowLimit", 0.25)
-    
+
     val genotypeFilter = new StrandBiasFilter(high, low)
 
     genotypeFilter.filter(rdd)
   }
 }
 
-private[postprocessing] class StrandBiasFilter (high: Double, low: Double) extends GenotypeFilter {
+private[postprocessing] class StrandBiasFilter(high: Double, low: Double) extends GenotypeFilter {
 
   /**
    * Filters genotypes that have a strand bias outside of acceptable range.
@@ -57,9 +57,9 @@ private[postprocessing] class StrandBiasFilter (high: Double, low: Double) exten
    * @param genotypes List of genotypes called at this site.
    * @return List of genotypes after filtering.
    */
-  def filterGenotypes (genotypes: Seq[ADAMGenotype]): Seq[ADAMGenotype] = {
+  def filterGenotypes(genotypes: Seq[ADAMGenotype]): Seq[ADAMGenotype] = {
     val keyed = genotypes.map(g => (Option(g.getReadDepth), Option(g.getReadsMappedForwardStrand), g))
-    
+
     val genotypesNoStats: Seq[ADAMGenotype] = keyed.filter(t => t._1.isEmpty || t._2.isEmpty)
       .map(t => t._3)
     val genotypesWithStats: Seq[ADAMGenotype] = keyed.filter(t => t._1.isDefined && t._2.isDefined)

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/postprocessing/PostprocessingStage.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/postprocessing/PostprocessingStage.scala
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.postprocessing
+package org.bdgenomics.avocado.postprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMGenotype
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.avro.ADAMGenotype
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 private[postprocessing] trait PostprocessingStage {
 
   val stageName: String
 
-  def apply (rdd: RDD[ADAMVariantContext], 
-             stats: AvocadoConfigAndStats,
-             config: SubnodeConfiguration): RDD[ADAMVariantContext]
+  def apply(rdd: RDD[ADAMVariantContext],
+            stats: AvocadoConfigAndStats,
+            config: SubnodeConfiguration): RDD[ADAMVariantContext]
 
 }
 
@@ -41,7 +41,7 @@ private[postprocessing] trait GenotypeFilter extends Serializable {
    * @param genotypes Genotypes to filter.
    * @return Filtered genotypes.
    */
-  def filterGenotypes (genotypes: Seq[ADAMGenotype]): Seq[ADAMGenotype]
+  def filterGenotypes(genotypes: Seq[ADAMGenotype]): Seq[ADAMGenotype]
 
   /**
    * Applies filtering and creates a new variant context, if called genotypes still exist.
@@ -52,10 +52,11 @@ private[postprocessing] trait GenotypeFilter extends Serializable {
    */
   def createNewVC(vc: ADAMVariantContext): Option[ADAMVariantContext] = {
     val filteredGt = filterGenotypes(vc.genotypes)
-    
+
     if (filteredGt.length > 0) {
       Some(ADAMVariantContext.buildFromGenotypes(filteredGt))
-    } else {
+    }
+    else {
       None
     }
   }
@@ -66,7 +67,7 @@ private[postprocessing] trait GenotypeFilter extends Serializable {
    * @param rdd RDD of variant contexts.
    * @return An RDD containing variant contexts after filtering.
    */
-  def filter (rdd: RDD[ADAMVariantContext]): RDD[ADAMVariantContext] = {
+  def filter(rdd: RDD[ADAMVariantContext]): RDD[ADAMVariantContext] = {
     rdd.flatMap(vc => createNewVC(vc))
   }
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/postprocessing/Postprocessor.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/postprocessing/Postprocessor.scala
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.postprocessing
+package org.bdgenomics.avocado.postprocessing
 
 import org.apache.commons.configuration.HierarchicalConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 object Postprocessor {
 
   private val stages = List[PostprocessingStage](FilterStrandBias,
-                                                 FilterDepth)
+    FilterDepth)
 
   assert(stages.map(_.stageName).length == stages.map(_.stageName).distinct.length,
-         "Postprocessing stages have duplicated names.")
+    "Postprocessing stages have duplicated names.")
 
-  def apply (rdd: RDD[ADAMVariantContext],
-             stageName: String,
-             stageAlgorithm: String,
-             stats: AvocadoConfigAndStats,
-             config: HierarchicalConfiguration): RDD[ADAMVariantContext] = {
-    
+  def apply(rdd: RDD[ADAMVariantContext],
+            stageName: String,
+            stageAlgorithm: String,
+            stats: AvocadoConfigAndStats,
+            config: HierarchicalConfiguration): RDD[ADAMVariantContext] = {
+
     val stage = stages.find(_.stageName == stageAlgorithm)
 
     stage match {
@@ -45,6 +45,6 @@ object Postprocessor {
       }
       case None => throw new IllegalArgumentException("Postprocessing stage " + stageAlgorithm + "does not exist.")
     }
-  }        
+  }
 
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/CoalesceReads.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/CoalesceReads.scala
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import org.bdgenomics.adam.avro.ADAMRecord
 
 object CoalesceReads extends PreprocessingStage {
-  
+
   val stageName = "coalesceReads"
 
-  def apply (rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
+  def apply(rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
     val partitions = config.getInt("partitions")
 
     rdd.coalesce(partitions, true)

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/MarkDuplicates.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/MarkDuplicates.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
 
 object MarkDuplicates extends PreprocessingStage {
-  
+
   val stageName = "markDuplicates"
 
-  def apply (rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
+  def apply(rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
     // no configuration needed, simply call mark duplicates
     rdd.adamMarkDuplicates()
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/PreprocessingStage.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/PreprocessingStage.scala
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import org.bdgenomics.adam.avro.ADAMRecord
 
 trait PreprocessingStage {
 
   val stageName: String
 
-  def apply (rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord]
+  def apply(rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord]
 
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/Preprocessor.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/Preprocessor.scala
@@ -14,33 +14,33 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import org.bdgenomics.adam.avro.ADAMRecord
 import org.apache.commons.configuration.HierarchicalConfiguration
 import org.apache.spark.rdd.RDD
 
 object Preprocessor {
 
   private val stages = List(MarkDuplicates,
-                            RecalibrateBaseQualities, 
-                            SortReads, 
-                            CoalesceReads,
-                            RealignIndels)
+    RecalibrateBaseQualities,
+    SortReads,
+    CoalesceReads,
+    RealignIndels)
 
-  def apply (rdd: RDD[ADAMRecord], 
-             stageName: String, 
-             stageAlgorithm: String,
-             config: HierarchicalConfiguration): RDD[ADAMRecord] = {
+  def apply(rdd: RDD[ADAMRecord],
+            stageName: String,
+            stageAlgorithm: String,
+            config: HierarchicalConfiguration): RDD[ADAMRecord] = {
 
     // get configuration for this stage
     val stageConfig = config.configurationAt(stageName)
 
     // find and run stage
     val stage = stages.find(_.stageName == stageAlgorithm)
-    
+
     assert(stage.isDefined, "Could not find stage with name: " + stageName)
     stage.get.apply(rdd, stageConfig)
   }
-  
+
 }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/RealignIndels.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/RealignIndels.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
 
 object RealignIndels extends PreprocessingStage {
-  
+
   val stageName = "realignIndels"
 
-  def apply (rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
+  def apply(rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
     // no configuration needed, simply call indel realigner
     rdd.adamRealignIndels()
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/RecalibrateBaseQualities.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/RecalibrateBaseQualities.scala
@@ -14,27 +14,28 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.models.SnpTable
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.models.SnpTable
+import org.bdgenomics.adam.rdd.ADAMContext._
 import java.io.File
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 
 object RecalibrateBaseQualities extends PreprocessingStage {
-  
+
   val stageName = "recalibrateBaseQualities"
 
-  def apply (rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
+  def apply(rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
     // check for snp table
     val snpTable = if (config.containsKey("snpTable")) {
       SnpTable(new File(config.getString("snpTable")))
-    } else {
+    }
+    else {
       SnpTable()
     }
-    
+
     // run bqsr with snp table loaded
     rdd.adamBQSR(snpTable)
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/SortReads.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/preprocessing/SortReads.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.preprocessing
+package org.bdgenomics.avocado.preprocessing
 
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
 
 object SortReads extends PreprocessingStage {
-  
+
   val stageName = "sortReads"
 
-  def apply (rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
+  def apply(rdd: RDD[ADAMRecord], config: SubnodeConfiguration): RDD[ADAMRecord] = {
     // no configuration needed, simply call sort
     rdd.adamSortReadsByReferencePosition()
   }

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/AvocadoConfigAndStats.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/AvocadoConfigAndStats.scala
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.stats
+package org.bdgenomics.avocado.stats
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMNucleotideContigFragment}
-import edu.berkeley.cs.amplab.adam.models.SequenceDictionary
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
-import edu.berkeley.cs.amplab.adam.rdd.AdamRDDFunctions
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMNucleotideContigFragment }
+import org.bdgenomics.adam.models.SequenceDictionary
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMRDDFunctions
 
-class AvocadoConfigAndStats (val sc: SparkContext,
-                             val debug: Boolean, 
-                             inputDataset: RDD[ADAMRecord],
-                             reference: RDD[ADAMNucleotideContigFragment]) {
-  
+class AvocadoConfigAndStats(val sc: SparkContext,
+                            val debug: Boolean,
+                            inputDataset: RDD[ADAMRecord],
+                            reference: RDD[ADAMNucleotideContigFragment]) {
+
   lazy val coverage = ScoreCoverage(inputDataset)
 
   lazy val contigLengths = GetReferenceContigLengths(reference)
-  
+
   lazy val referenceSeq = reference.collect()
 
   lazy val sequenceDict = reference.adamGetSequenceDictionary()

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/GetReferenceContigLengths.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/GetReferenceContigLengths.scala
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.stats
+package org.bdgenomics.avocado.stats
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.ADAMNucleotideContigFragment
+import org.bdgenomics.adam.avro.ADAMNucleotideContigFragment
 
 private[stats] object GetReferenceContigLengths {
-  
+
   /**
    * From a rdd of reference contigs, collects their lengths in an array.
    *
    * @param rdd RDD of reference contigs.
    * @return List of contig lengths.
    */
-  def apply (rdd: RDD[ADAMNucleotideContigFragment]): Map[Int, Long] = {
+  def apply(rdd: RDD[ADAMNucleotideContigFragment]): Map[Int, Long] = {
     rdd.map(c => (c.getContigId.toInt, c.getContigLength.toLong)).distinct.collect.toMap
   }
 

--- a/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/ScoreCoverage.scala
+++ b/avocado-core/src/main/scala/edu/berkeley/cs/amplab/avocado/stats/ScoreCoverage.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.stats
+package org.bdgenomics.avocado.stats
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
-import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rich.RichADAMRecord
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -26,22 +26,22 @@ private[stats] object ScoreCoverage {
 
   // TODO: correct for whole genome without gaps, incorrect if gaps are present
   def apply(rdd: RDD[ADAMRecord]): Double = {
-    
-    def coverageReducer (t1: (Long, Long, Long), t2: (Long, Long, Long)): (Long, Long, Long) = {
+
+    def coverageReducer(t1: (Long, Long, Long), t2: (Long, Long, Long)): (Long, Long, Long) = {
       (t1._1 min t2._1,
-       t1._2 max t2._1,
-       t1._3 +   t2._3)
+        t1._2 max t2._1,
+        t1._3 + t2._3)
     }
-    
-    def readToParams (r: ADAMRecord): (Long, Long, Long) = {
+
+    def readToParams(r: ADAMRecord): (Long, Long, Long) = {
       val s = r.getStart
       val e = r.end.get
       (s, e, e - s + 1)
     }
-    
+
     val (start, end, bases) = rdd.filter(_.getReadMapped).map(readToParams)
       .reduce(coverageReducer(_, _))
-    
+
     bases.toDouble / (end - start).toDouble
   }
 

--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/calls/pileup/PileupCallSimpleSuite.scala
@@ -14,34 +14,34 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.calls.pileup
+package org.bdgenomics.avocado.calls.pileup
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import edu.berkeley.cs.amplab.adam.avro.{ADAMPileup, Base}
-import edu.berkeley.cs.amplab.adam.models.{ADAMRod, ADAMVariantContext}
+import org.bdgenomics.adam.avro.{ ADAMPileup, Base }
+import org.bdgenomics.adam.models.{ ADAMRod, ADAMVariantContext }
 import scala.collection.JavaConversions._
-import org.scalatest.FunSuite 
+import org.scalatest.FunSuite
 import scala.math.abs
 
 class PileupCallSimpleSuite extends FunSuite {
 
   val floatingPointingThreshold = 1e-6
 
-  def assertAlmostEqual(a: Double, b: Double, epsilon : Double = floatingPointingThreshold) {
+  def assertAlmostEqual(a: Double, b: Double, epsilon: Double = floatingPointingThreshold) {
     assert((a * 0.99 < b && a * 1.01 > b) ||
-           abs(a - b) < epsilon)
+      abs(a - b) < epsilon)
   }
 
   test("Collect the max non-ref base for homozygous SNP") {
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .build())
+      .setReadBase(Base.A)
+      .setReferenceBase(Base.C)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.A)
+        .setReferenceBase(Base.C)
+        .build())
 
     val call = new PileupCallSimpleSNP(2)
 
@@ -53,13 +53,13 @@ class PileupCallSimpleSuite extends FunSuite {
 
   test("Collect the max non-ref base for hetereozygous SNP") {
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .build())
+      .setReadBase(Base.C)
+      .setReferenceBase(Base.C)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.A)
+        .setReferenceBase(Base.C)
+        .build())
 
     val call = new PileupCallSimpleSNP(2)
 
@@ -71,17 +71,17 @@ class PileupCallSimpleSuite extends FunSuite {
 
   test("Collect the max non-ref base for homozygous SNP that is not biallelic") {
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.T)
-                    .setReferenceBase(Base.C)
-                    .build())
+      .setReadBase(Base.A)
+      .setReferenceBase(Base.C)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.A)
+        .setReferenceBase(Base.C)
+        .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.T)
+        .setReferenceBase(Base.C)
+        .build())
 
     val call = new PileupCallSimpleSNP(2)
 
@@ -93,13 +93,13 @@ class PileupCallSimpleSuite extends FunSuite {
 
   test("Do not collect the max non-ref base for homozygous ref.") {
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .build())
+      .setReadBase(Base.C)
+      .setReferenceBase(Base.C)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.C)
+        .setReferenceBase(Base.C)
+        .build())
 
     val call = new PileupCallSimpleSNP(2)
 
@@ -110,7 +110,7 @@ class PileupCallSimpleSuite extends FunSuite {
 
   test("Default compensation method doesn't perform any compensation") {
     val call = new PileupCallSimpleSNP(2)
-    
+
     val l = List(0.0, 0.0, 0.0)
 
     assert(l === call.compensate(l, List[ADAMPileup]()))
@@ -120,32 +120,31 @@ class PileupCallSimpleSuite extends FunSuite {
     val call = new PileupCallSimpleSNP(2)
 
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(30)
-                    .setSangerQuality(30)
-                    .setCountAtPosition(1)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(40)
-                    .setSangerQuality(40)
-                    .setCountAtPosition(1)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(40)
-                    .setSangerQuality(30)
-                    .setCountAtPosition(1)
-                    .build()
-                  )
+      .setReadBase(Base.C)
+      .setReferenceBase(Base.C)
+      .setMapQuality(30)
+      .setSangerQuality(30)
+      .setCountAtPosition(1)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.C)
+        .setReferenceBase(Base.C)
+        .setMapQuality(40)
+        .setSangerQuality(40)
+        .setCountAtPosition(1)
+        .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.C)
+        .setReferenceBase(Base.C)
+        .setMapQuality(40)
+        .setSangerQuality(30)
+        .setCountAtPosition(1)
+        .build())
 
     val expected = List((8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999)) / 8.0,
-                        ((0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999) +
-                         (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999)) / 8.0,
-                        8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999) / 8.0).reverse
+      ((0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999) +
+        (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999)) / 8.0,
+      8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999) / 8.0).reverse
 
     val scored = call.scoreGenotypeLikelihoods(pl)
 
@@ -158,32 +157,31 @@ class PileupCallSimpleSuite extends FunSuite {
     val call = new PileupCallSimpleSNP(2)
 
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(30)
-                    .setSangerQuality(30)
-                    .setCountAtPosition(1)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.C)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(40)
-                    .setSangerQuality(40)
-                    .setCountAtPosition(1)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(40)
-                    .setSangerQuality(30)
-                    .setCountAtPosition(1)
-                    .build()
-                  )
+      .setReadBase(Base.C)
+      .setReferenceBase(Base.C)
+      .setMapQuality(30)
+      .setSangerQuality(30)
+      .setCountAtPosition(1)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.C)
+        .setReferenceBase(Base.C)
+        .setMapQuality(40)
+        .setSangerQuality(40)
+        .setCountAtPosition(1)
+        .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.A)
+        .setReferenceBase(Base.C)
+        .setMapQuality(40)
+        .setSangerQuality(30)
+        .setCountAtPosition(1)
+        .build())
     //TODO(arahuja) test is not correct as multiplying probabilities is not exactly the same as averaging qual scores
     val expected = List((8.0 * ((0.999 * 0.999) * (0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999))) / 8.0,
 
-      ((0.999 * 0.999 + (1.0 - 0.999 * 0.999)) *  (0.9999 * 0.9999 + (1.0 - 0.9999 * 0.9999))
-        *  ((1.0 - 0.999 * 0.9999) + (0.999 * 0.9999) )) / 8.0,
+      ((0.999 * 0.999 + (1.0 - 0.999 * 0.999)) * (0.9999 * 0.9999 + (1.0 - 0.9999 * 0.9999))
+        * ((1.0 - 0.999 * 0.9999) + (0.999 * 0.9999))) / 8.0,
       (8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (0.999 * 0.9999)) / 8.0).reverse
 
     val scored = call.scoreGenotypeLikelihoods(pl)
@@ -197,33 +195,31 @@ class PileupCallSimpleSuite extends FunSuite {
     val call = new PileupCallSimpleSNP(2)
 
     val pl = List(ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(30)
-                    .setSangerQuality(30)
-                    .setCountAtPosition(1)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(40)
-                    .setSangerQuality(40)
-                    .setCountAtPosition(1)
-                    .build(),
-                  ADAMPileup.newBuilder()
-                    .setReadBase(Base.A)
-                    .setReferenceBase(Base.C)
-                    .setMapQuality(40)
-                    .setSangerQuality(30)
-                    .setCountAtPosition(1)
-                    .build()
-                  )
+      .setReadBase(Base.A)
+      .setReferenceBase(Base.C)
+      .setMapQuality(30)
+      .setSangerQuality(30)
+      .setCountAtPosition(1)
+      .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.A)
+        .setReferenceBase(Base.C)
+        .setMapQuality(40)
+        .setSangerQuality(40)
+        .setCountAtPosition(1)
+        .build(),
+      ADAMPileup.newBuilder()
+        .setReadBase(Base.A)
+        .setReferenceBase(Base.C)
+        .setMapQuality(40)
+        .setSangerQuality(30)
+        .setCountAtPosition(1)
+        .build())
 
     val expected = List(8.0 * (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999) / 8.0,
-                        ((0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999) +
-                         (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999)) / 8.0,
-                        (8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999)) / 8.0).reverse
-   
+      ((0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999) +
+        (1.0 - 0.999 * 0.999) * (1.0 - 0.9999 * 0.9999) * (1.0 - 0.999 * 0.9999)) / 8.0,
+      (8.0 * (0.999 * 0.999 * 0.9999 * 0.9999 * 0.999 * 0.9999)) / 8.0).reverse
 
     val scored = call.scoreGenotypeLikelihoods(pl)
 

--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/partitioners/DefaultPartitionerSuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/partitioners/DefaultPartitionerSuite.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.partitioners
+package org.bdgenomics.avocado.partitioners
 
-import edu.berkeley.cs.amplab.adam.models.ReferenceRegion
+import org.bdgenomics.adam.models.ReferenceRegion
 import org.scalatest.FunSuite
 import scala.collection.immutable.SortedMap
 
@@ -26,7 +26,7 @@ class DefaultPartitionerSuite extends FunSuite {
   val partitioner = new DefaultPartitioner(contigs, 100)
   val partitions = partitioner.computePartitions()
 
-  test ("build a single partiton per contig") {
+  test("build a single partiton per contig") {
     val regions = contigs.toList.map(kv => ReferenceRegion(kv._1, 0, kv._2))
 
     regions.foreach(r => {
@@ -35,7 +35,7 @@ class DefaultPartitionerSuite extends FunSuite {
     })
   }
 
-  test ("check that offsets are correct") {
+  test("check that offsets are correct") {
     val ctg0 = ReferenceRegion(0, 0, 99L)
     assert(partitions.isInSet(ctg0))
     assert(!partitions.isOutsideOfSet(ctg0))
@@ -55,7 +55,7 @@ class DefaultPartitionerSuite extends FunSuite {
     assert(partitions.getPartition(ctg2).head === 15)
   }
 
-  test ("default partition set properly handles regions that span buckets") {
+  test("default partition set properly handles regions that span buckets") {
     val ctg0 = ReferenceRegion(0, 0, 299L)
     assert(partitions.isInSet(ctg0))
     assert(!partitions.isOutsideOfSet(ctg0))
@@ -65,19 +65,19 @@ class DefaultPartitionerSuite extends FunSuite {
     assert(partitions.getPartition(ctg0).contains(2))
   }
 
-  test ("throws exception for contigs not in reference") {
+  test("throws exception for contigs not in reference") {
     val ctg3 = ReferenceRegion(3, 0, 100L)
 
-    intercept [IllegalArgumentException] {
+    intercept[IllegalArgumentException] {
       partitions.getPartition(ctg3)
     }
   }
 
-  test ("throws exception for contigs that extend past ends of reference contigs") {
+  test("throws exception for contigs that extend past ends of reference contigs") {
     val ctg0 = ReferenceRegion(0, 900L, 1100L)
     assert(partitions.isInSet(ctg0))
 
-    intercept [IllegalArgumentException] {
+    intercept[IllegalArgumentException] {
       partitions.getPartition(ctg0)
     }
   }

--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/partitioners/PartitionSetSuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/partitioners/PartitionSetSuite.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.partitioners
+package org.bdgenomics.avocado.partitioners
 
-import edu.berkeley.cs.amplab.adam.models.ReferenceRegion
+import org.bdgenomics.adam.models.ReferenceRegion
 import org.scalatest.FunSuite
 import scala.collection.immutable.SortedMap
 
 class PartitionSetSuite extends FunSuite {
 
   val regionMapping = SortedMap(ReferenceRegion(0, 0L, 100L) -> 0,
-                                ReferenceRegion(0, 100L, 200L) -> 1,
-                                ReferenceRegion(0, 300L, 400L) -> 2)
+    ReferenceRegion(0, 100L, 200L) -> 1,
+    ReferenceRegion(0, 300L, 400L) -> 2)
   val partitionSet = new PartitionSet(regionMapping)
 
-  test ("region that is fully contained in a single partition") {
+  test("region that is fully contained in a single partition") {
     val r = ReferenceRegion(0, 10L, 40L)
 
     assert(partitionSet.isInSet(r))
@@ -36,7 +36,7 @@ class PartitionSetSuite extends FunSuite {
     assert(partitionSet.getPartition(r).head === 0)
   }
 
-  test ("region that is fully contained in two adjacent partitions") {
+  test("region that is fully contained in two adjacent partitions") {
     val r = ReferenceRegion(0, 90L, 120L)
 
     assert(partitionSet.isInSet(r))
@@ -46,7 +46,7 @@ class PartitionSetSuite extends FunSuite {
     assert(partitionSet.getPartition(r).contains(1))
   }
 
-  test ("region that is in two adjacent partitions, but extends outside of them as well") {
+  test("region that is in two adjacent partitions, but extends outside of them as well") {
     val r = ReferenceRegion(0, 90L, 220L)
 
     assert(partitionSet.isInSet(r))
@@ -56,7 +56,7 @@ class PartitionSetSuite extends FunSuite {
     assert(partitionSet.getPartition(r).contains(1))
   }
 
-  test ("region that is in two partitions with a gap between them") {
+  test("region that is in two partitions with a gap between them") {
     val r = ReferenceRegion(0, 170L, 320L)
 
     assert(partitionSet.isInSet(r))
@@ -66,7 +66,7 @@ class PartitionSetSuite extends FunSuite {
     assert(partitionSet.getPartition(r).contains(2))
   }
 
-  test ("region that is fully outside of the set") {
+  test("region that is fully outside of the set") {
     val r = ReferenceRegion(0, 450L, 550L)
 
     assert(!partitionSet.isInSet(r))

--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/postprocessing/FilterDepthSuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/postprocessing/FilterDepthSuite.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.postprocessing
+package org.bdgenomics.avocado.postprocessing
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMGenotype, ADAMVariant}
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
-import org.scalatest.FunSuite 
+import org.bdgenomics.adam.avro.{ ADAMContig, ADAMGenotype, ADAMVariant }
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
+import org.scalatest.FunSuite
 
 class FilterDepthSuite extends FunSuite {
 
   test("do not filter genotypes that have no depth info") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -46,9 +46,9 @@ class FilterDepthSuite extends FunSuite {
 
   test("do not filter genotypes that have sufficient coverage") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -68,9 +68,9 @@ class FilterDepthSuite extends FunSuite {
 
   test("filter genotypes that have low coverage") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -90,9 +90,9 @@ class FilterDepthSuite extends FunSuite {
 
   test("do not filter genotypes that have no depth info or that have sufficient coverage") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -117,9 +117,9 @@ class FilterDepthSuite extends FunSuite {
 
   test("do not filter genotypes that have no depth info but filter low coverage calls") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -143,5 +143,5 @@ class FilterDepthSuite extends FunSuite {
     assert(filt.filterGenotypes(seq).filter(_.getSampleId == "me").length === 2)
     assert(filt.filterGenotypes(seq).filter(_.getSampleId == "you").length === 0)
   }
-  }
+}
 

--- a/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/postprocessing/FilterStrandBiasSuite.scala
+++ b/avocado-core/src/test/scala/edu/berkeley/cs/amplab/avocado/postprocessing/FilterStrandBiasSuite.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.avocado.postprocessing
+package org.bdgenomics.avocado.postprocessing
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMGenotype, ADAMVariant}
-import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
-import edu.berkeley.cs.amplab.avocado.stats.AvocadoConfigAndStats
-import org.scalatest.FunSuite 
+import org.bdgenomics.adam.avro.{ ADAMContig, ADAMGenotype, ADAMVariant }
+import org.bdgenomics.adam.models.ADAMVariantContext
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
+import org.scalatest.FunSuite
 
 class FilterStrandBiasSuite extends FunSuite {
 
   test("do not filter genotypes that have no strand biasing info") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -46,9 +46,9 @@ class FilterStrandBiasSuite extends FunSuite {
 
   test("do not filter genotypes that are inside bounds") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -69,9 +69,9 @@ class FilterStrandBiasSuite extends FunSuite {
 
   test("filter genotypes that are outside bounds") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -92,9 +92,9 @@ class FilterStrandBiasSuite extends FunSuite {
 
   test("do not filter genotypes that have no strand biasing info or that are inside bounds") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -120,9 +120,9 @@ class FilterStrandBiasSuite extends FunSuite {
 
   test("do not filter genotypes that have no strand biasing info but filter those that are outside bounds") {
     val contig = ADAMContig.newBuilder
-        .setContigId(0)
-        .setContigName("0")
-        .build
+      .setContigId(0)
+      .setContigName("0")
+      .build
     val variant = ADAMVariant.newBuilder
       .setContig(contig)
       .setPosition(0)
@@ -146,5 +146,5 @@ class FilterStrandBiasSuite extends FunSuite {
     assert(filt.filterGenotypes(seq).filter(_.getSampleId == "me").length === 2)
     assert(filt.filterGenotypes(seq).filter(_.getSampleId == "you").length === 0)
   }
-  
+
 }

--- a/avocado-sufficient-statistics/pom.xml
+++ b/avocado-sufficient-statistics/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>edu.berkeley.cs.amplab.avocado</groupId>
+    <groupId>org.bdgenomics.avocado</groupId>
     <artifactId>avocado</artifactId>
     <version>0.0.2</version>
     <relativePath>../pom.xml</relativePath>

--- a/avocado-sufficient-statistics/src/main/resources/avro/avocado-sufficient-statistics.avdl
+++ b/avocado-sufficient-statistics/src/main/resources/avro/avocado-sufficient-statistics.avdl
@@ -1,4 +1,4 @@
-@namespace("edu.berkeley.cs.amplab.avocado.avro")
+@namespace("org.bdgenomics.avocado.avro")
 protocol avocado {
 
 record AvocadoStatisticEntry {

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>edu.berkeley.cs.amplab.avocado</groupId>
+  <groupId>org.bdgenomics.avocado</groupId>
   <artifactId>avocado</artifactId>
   <version>0.0.2</version>
   <packaging>pom</packaging>
   <name>avocado: A Variant Caller, Distributed</name>
 
   <properties>
-    <adam.version>0.7.3-SNAPSHOT</adam.version>
+    <adam.version>0.8.1-SNAPSHOT</adam.version>
     <avro.version>1.7.4</avro.version>
     <java.version>1.6</java.version>
     <scala.version>2.10.3</scala.version>
@@ -159,10 +159,29 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.scalariform</groupId>
+        <artifactId>scalariform-maven-plugin</artifactId>
+        <version>0.1.4</version>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+            <configuration>
+              <alignParameters>true</alignParameters>
+              <alignSingleLineCaseStatements>true</alignSingleLineCaseStatements>
+              <compactControlReadability>true</compactControlReadability>
+              <doubleIndentClassDeclaration>true</doubleIndentClassDeclaration>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
-  <repositories> 
+  <repositories>
     <repository>
       <id>Sonatype</id>
       <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -179,17 +198,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>edu.berkeley.cs.amplab.adam</groupId>
+      <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-format</artifactId>
       <version>${adam.version}</version>
     </dependency>
     <dependency>
-      <groupId>edu.berkeley.cs.amplab.adam</groupId>
+      <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-core</artifactId>
       <version>${adam.version}</version>
     </dependency>
     <dependency>
-      <groupId>edu.berkeley.cs.amplab.adam</groupId>
+      <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-cli</artifactId>
       <version>${adam.version}</version>
     </dependency>

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,37 @@
+# This script is shamelessly taken from the Parquet team @ https://github.com/Parquet/parquet-mr
+
+echo "github username:" >&2 
+read username >&2
+echo "github password:" >&2 
+read -s password >&2
+
+curl -f -u $username:$password -s "https://api.github.com" > /dev/null
+if [ $? == 0 ]
+then
+  echo "login successful" >&2
+else
+  echo "login failed" >&2
+  curl -u $username:$password -s "https://api.github.com"
+  exit 1
+fi
+
+echo "# avocado #"
+
+git log | grep -E "Merge pull request|prepare release" | while read l
+do 
+  release=`echo $l | grep "\[maven-release-plugin\] prepare release" | cut -d "-" -f 4`
+  PR=`echo $l| grep -E -o "Merge pull request #[^ ]*" | cut -d "#" -f 2`
+#  echo $l
+  if [ -n "$release" ] 
+  then 
+    echo
+    echo "### Version $release ###"
+  fi
+  if [ -n "$PR" ]
+  then
+    JSON=`curl -u $username:$password -s https://api.github.com/repos/bigdatagenomics/adam/pulls/$PR | tr "\n" " "`
+    DESC_RAW=$(echo $JSON |  grep -Po '"title":.*?[^\\]",' | cut -d "\"" -f 4- | head -n 1 | sed -e "s/\\\\//g")
+    DESC=$(echo ${DESC_RAW%\",})
+    echo "* ISSUE [$PR](https://github.com/bigdatagenomics/adam/pull/$PR): ${DESC}"
+  fi
+done


### PR DESCRIPTION
This pull request makes the following changes:
- Moves all packages to org.bdgenomics
- Upgrades ADAM to 0.8.1-SNAPSHOT. This requires us to do s/Adam/ADAM/g, as well as s/edu.berkeley.cs.amplab.adam/org.bdgenomics.adam/g.
- Runs [scalariform](https://github.com/mdr/scalariform) on all files.
- Adds changelog (CHANGES.md, updated via scripts/changelog.sh)
- Adds CONTRIBUTING.md file.
