### PR TITLE
Change snp caller interface to use rods exclusively

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/Avocado.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/Avocado.scala
@@ -21,7 +21,7 @@ import org.apache.commons.configuration.plist.PropertyListConfiguration
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{ SparkContext, Logging }
-import org.kohsuke.args4j.{Option => option, Argument}
+import org.kohsuke.args4j.{ Option => option, Argument }
 import org.bdgenomics.adam.avro.{ ADAMVariant, ADAMRecord, ADAMNucleotideContigFragment }
 import org.bdgenomics.adam.cli.{
   ADAMSparkCommand,

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/VariantCaller.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/VariantCaller.scala
@@ -21,13 +21,14 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMPileup, ADAMVariant, ADAMGenotype }
 import org.bdgenomics.adam.models.ADAMVariantContext
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.avocado.calls.pileup.{ PileupCallSimpleSNP, PileupCallUnspecified }
+import org.bdgenomics.avocado.calls.pileup.{ MPileupCallSimpleSNP, PileupCallSimpleSNP, PileupCallUnspecified }
 import org.bdgenomics.avocado.calls.reads.{ ReadCallAssemblyPhaser, ReadCallUnspecified }
 import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 
 object VariantCaller {
 
   private val calls = List(PileupCallSimpleSNP,
+    MPileupCallSimpleSNP,
     PileupCallUnspecified,
     ReadCallAssemblyPhaser,
     ReadCallUnspecified)

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/pileup/MPileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/pileup/MPileupCallSimpleSNP.scala
@@ -60,11 +60,11 @@ class MPileupCallSimpleSNP(ploidy: Int,
    * Takes in a single pileup rod from a single sample at a single locus. For simplicity, we assume that
    * all sites are biallelic.
    *
-   * @param[in] pileup List of pileups. Should only contain one rod.
+   * @param[in] rod ADAMRod
    * @return List of variants seen at site. List can contain 0 or 1 elements - value goes to flatMap.
    */
-  protected def callSNP(pileup: ADAMRod): List[ADAMVariantContext] = {
-    val samples = pileup.splitBySamples
+  protected override def callSNP(rod: ADAMRod): List[ADAMVariantContext] = {
+    val samples = rod.splitBySamples
 
     // score off of rod info
     val likelihoods: Array[Array[(Double, Double, Double)]] = samples.map(_.pileups)
@@ -90,7 +90,7 @@ class MPileupCallSimpleSNP(ploidy: Int,
     var g = List[ADAMGenotype]()
 
     // get most often seen non-reference base
-    val maxNonRefBase = getMaxNonRefBase(pileup.pileups)
+    val maxNonRefBase = getMaxNonRefBase(rod.pileups)
 
     // loop over samples and write calls to list
     for (i <- 0 until likelihoods.length) {

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/pileup/PileupCallSimpleSNP.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/pileup/PileupCallSimpleSNP.scala
@@ -272,11 +272,11 @@ class PileupCallSimpleSNP(ploidy: Int) extends PileupCall {
    * Takes in a single pileup rod from a single sample at a single locus. For simplicity, we assume that
    * all sites are biallelic.
    *
-   * @param[in] pileup List of pileups. Should only contain one rod.
+   * @param[in] rod ADAMRod
    * @return List of variants seen at site. List can contain 0 or 1 elements - value goes to flatMap.
    */
-  protected def callSNP(pileup: List[ADAMPileup]): List[ADAMVariantContext] = {
-
+  protected def callSNP(rod: ADAMRod): List[ADAMVariantContext] = {
+    val pileup = rod.pileups
     if (pileup.forall(_.getRangeLength == null)) {
       val loci = pileup.head.getPosition
       log.info("Calling pileup at " + loci)
@@ -302,12 +302,12 @@ class PileupCallSimpleSNP(ploidy: Int) extends PileupCall {
   /**
    * Call variants using simple pileup based SNP calling algorithm.
    *
-   * @param[in] pileupGroups An RDD containing lists of pileups.
+   * @param[in] pileups An RDD containing of ADAMRods.
    * @return An RDD containing called variants.
    */
   override def callRods(pileups: RDD[ADAMRod]): RDD[ADAMVariantContext] = {
     log.info("Calling SNPs on pileups and flattening.")
-    pileups.map(_.pileups)
+    pileups
       .map(callSNP)
       .flatMap((p: List[ADAMVariantContext]) => p)
   }


### PR DESCRIPTION
As mentioned in issue #9 the SimpleSNP caller and MPileupSNP caller differ in their callSNP functions so the parent-level call  function on RDD[ADAMRead] only uses the pileup one in SimpleSNP and not the rod one in MPileup.  This changes both to use rods.

Hopefully this will be helped further by changes to the pileup interface.
