### PR TITLE
Fix scheme issue with HDFS

### DIFF
--- a/avocado-core/pom.xml
+++ b/avocado-core/pom.xml
@@ -34,6 +34,7 @@
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>reference.conf</resource>
             </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
           </transformers>
           <finalName>avocado-${project.version}</finalName>
           <filters>
@@ -148,6 +149,11 @@
   </build>
 
   <dependencies>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <version>${hadoop.version}</version>
+      </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-format</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
     <java.version>1.6</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
+      <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
+    <hadoop.version>2.2.0</hadoop.version>
   </properties>
 
   <modules>
@@ -147,7 +149,7 @@
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
-          <filereports>ADAMTestSuite.txt</filereports>
+          <filereports>AvocadoTestSuite.txt</filereports>
           <argLine>-Xmx1024m</argLine>
         </configuration>
         <executions>
@@ -186,16 +188,35 @@
       <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
     <repository>
-      <id>hadoop-bam</id>
-      <url>http://hadoop-bam.sourceforge.net/maven/</url>
-    </repository>
-    <repository>
       <id>Apache</id>
       <url>http://people.apache.org/repo/m2-snapshot-repository</url>
     </repository>
   </repositories>
 
   <dependencies>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <version>${hadoop.version}</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>asm</groupId>
+                  <artifactId>asm</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.jboss.netty</groupId>
+                  <artifactId>netty</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.codehaus.jackson</groupId>
+                  <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.sonatype.sisu.inject</groupId>
+                  <artifactId>*</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-format</artifactId>


### PR DESCRIPTION
We had the same 'hdfs scheme not recognized' error that was there earlier in adam which this fixes.
- Added an explicit Hadoop dependency (kept version 2.2 as that is the default in Adam)
- Removed unused repo
