### PR TITLE
Refactor HMMAligner and add testing for HMMAligner

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/debrujin/Kmer.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/debrujin/Kmer.scala
@@ -75,7 +75,13 @@ class KmerPath(val edges: Seq[Kmer]) extends Ordered[KmerPath] {
     this.haplotypeString == kp.haplotypeString
   }
 
-  def compare(otherPath: KmerPath): Int = {
-    weight.compare(otherPath.weight)
+  override def compare(otherPath: KmerPath): Int = {
+    if (equals(otherPath)) {
+      weight.compare(otherPath.weight)
+    } else if (weight > otherPath.weight) {
+      1
+    } else {
+      -1
+    }
   }
 }

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraph.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraph.scala
@@ -145,12 +145,13 @@ class KmerGraph(val kmerLength: Int, val readLength: Int, val regionLength: Int,
   /**
    * Performs depth first search and scores all paths through the final graph.
    */
-  def enumerateAllPaths(maxDepth: Int): collection.mutable.PriorityQueue[KmerPath] = {
-    val queue = new collection.mutable.PriorityQueue[KmerPath]()
+  def enumerateAllPaths(maxDepth: Int): collection.mutable.SortedSet[KmerPath] = {
+    val paths = collection.mutable.SortedSet[KmerPath]()
 
     def pathToSink(node: Kmer, currentPath: Seq[Kmer], depth: Int): Unit = {
       if (node.nextPrefix.equals(sinkKmer.nextPrefix) || depth > maxDepth) {
-        queue.enqueue(new KmerPath(currentPath :+ node))
+        val path = new KmerPath(currentPath :+ node)
+        paths.add(path)
       }
       val nextNodes = kmerGraph.get(node.nextPrefix)
       if (depth <= maxDepth && nextNodes.isDefined && nextNodes.nonEmpty) {
@@ -159,7 +160,7 @@ class KmerGraph(val kmerLength: Int, val readLength: Int, val regionLength: Int,
     }
 
     pathToSink(sourceKmer, Seq.empty, 0)
-    queue
+    paths
   }
 
   def exciseKmer(kmer: Kmer) = {

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Alignment.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Alignment.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.avocado.algorithms.hmm
+
+object AlignmentState extends Enumeration {
+  type AlignmentState = Value
+  val Insertion, Match, Mismatch, Deletion = Value
+
+  def isIndel(state: AlignmentState): Boolean = {
+    state match {
+      case Insertion | Deletion => true
+      case _                    => false
+    }
+  }
+}
+
+class Alignment(val likelihood: Double, val prior: Double, val alignedReference: String, val alignedSequence: String, val alignmentStateSequence: String, val hasVariants: Boolean = false) {
+
+  lazy val alignment = generateCompressedStateSequence(alignmentStateSequence)
+
+  /**
+   * Performs a run-length encoding on the alignment state sequence
+   */
+  def generateCompressedStateSequence(unitAlignment: String): List[(Int, Char)] = {
+    if (unitAlignment.size == 0) return List[(Int, Char)]()
+
+    val (run, tail) = unitAlignment.span(_ == unitAlignment.head)
+    (run.size, unitAlignment.head) :: generateCompressedStateSequence(tail)
+  }
+}

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Haplotype.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Haplotype.scala
@@ -1,8 +1,21 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bdgenomics.avocado.algorithms.hmm
 
-import scala.collection.mutable.ArrayBuffer
-import org.bdgenomics.adam.avro.ADAMRecord
-import scala.math._
 import scala.math.Ordering
 import org.bdgenomics.adam.rich.RichADAMRecord
 
@@ -11,17 +24,15 @@ import org.bdgenomics.adam.rich.RichADAMRecord
  *
  * @param sequence String representing haplotype alignment.
  */
-class Haplotype(val sequence: String, region: Seq[RichADAMRecord], val reference: String = "") {
+class Haplotype(val sequence: String, region: Seq[RichADAMRecord], hmm: HMMAligner = new HMMAligner, val reference: String = "") {
 
-  val hmm = new HMMAligner()
-  val hasVariants = hmm.alignSequences(reference, sequence, null)
-  val alignment = hmm.getAlignment()
+  lazy val referenceAlignment = hmm.alignSequences(reference, sequence, null)
+  lazy val hasVariants = referenceAlignment.hasVariants
 
-  val perReadLikelihoods: Seq[Double] = region.map(read => {
+  lazy val perReadLikelihoods: Seq[Double] = region.map(read => {
     try {
-      hmm.alignSequences(sequence, read.getSequence.toString, null)
-      val readLikelihood = hmm.getLikelihood + hmm.getPrior
-      readLikelihood
+      val alignment = HMMAligner.align(sequence, read.getSequence.toString, null)
+      alignment.likelihood + alignment.prior
     } catch {
       case _: Throwable => {
         0.0
@@ -29,7 +40,7 @@ class Haplotype(val sequence: String, region: Seq[RichADAMRecord], val reference
     }
   })
 
-  val readsLikelihood = perReadLikelihoods.sum
+  lazy val readsLikelihood = perReadLikelihoods.sum
 
   override def toString(): String = {
     sequence
@@ -52,96 +63,10 @@ object HaplotypeOrdering extends Ordering[Haplotype] {
    * @return Ordering info for haplotypes.
    */
   def compare(h1: Haplotype, h2: Haplotype): Int = {
-    if (h1.sequence == h2.sequence) {
-      h1.readsLikelihood.compare(h2.readsLikelihood)
-    } else if (h1.readsLikelihood < h2.readsLikelihood) {
+    if (h1.readsLikelihood < h2.readsLikelihood) {
       -1
     } else {
       1
-    }
-  }
-}
-
-object HaplotypePair {
-
-  /**
-   * Exponentiates two numbers by base of 10, adds together, takes base 10 log, and returns.
-   *
-   * @param x1 First digit to sum.
-   * @param x2 Second digit to sum.
-   * @return Sum of two digits after exponentation and logarithm.
-   *
-   * @see approxLogSumExp10
-   */
-  def exactLogSumExp10(x1: Double, x2: Double): Double = {
-    log10(pow(10.0, x1) + pow(10.0, x2))
-  }
-
-  /**
-   * Exponentiates two numbers by base of 10, adds together, takes base 10 log, and returns.
-   *
-   * @param x1 First digit to sum.
-   * @param x2 Second digit to sum.
-   * @return Sum of two digits after exponentation and logarithm.
-   *
-   * @see exactLogSumExp10
-   */
-  def approxLogSumExp10(x1: Double, x2: Double): Double = {
-    exactLogSumExp10(x1, x2)
-  }
-
-}
-
-/**
- * Class for a pairing of two haplotypes.
- *
- * @param haplotype1 First haplotype of pair.
- * @param haplotype2 Second haplotype of pair.
- */
-class HaplotypePair(val haplotype1: Haplotype, val haplotype2: Haplotype, hmm: HMMAligner) {
-
-  val hasVariants = haplotype1.hasVariants || haplotype2.hasVariants
-  val pairLikelihood = scorePairLikelihood
-
-  override def toString(): String = {
-    haplotype1.sequence + ", " + haplotype2.sequence + ", " + ("%1.3f" format pairLikelihood)
-  }
-
-  /**
-   * Scores likelihood of two paired haplotypes and their alignment.
-   *
-   * @return Phred scaled likelihood.
-   */
-  def scorePairLikelihood: Double = {
-    val readsProb = haplotype1.perReadLikelihoods.zip(haplotype1.perReadLikelihoods).map(scores => HaplotypePair.exactLogSumExp10(scores._1, scores._2) - log10(2.0)).sum
-    hmm.alignSequences(haplotype2.sequence, haplotype1.sequence, null)
-    val priorProb = hmm.getPrior
-    readsProb + priorProb
-  }
-
-}
-
-/**
- * Haplotype pairs are ordered by increasing pairwise likelihood, assuming
- *  they come from the same read group.
- */
-object HaplotypePairOrdering extends Ordering[HaplotypePair] {
-
-  /**
-   * Compares two haplotype pairs. Returns (-1, 0, 1) if first pair has (lower, same, higher)
-   * pairwise likelihood.
-   *
-   * @param pair1 First haplotype pair to compare.
-   * @param pair2 Second haplotype pair to compare.
-   * @return Comparison of haplotype pairs.
-   */
-  def compare(pair1: HaplotypePair, pair2: HaplotypePair): Int = {
-    if (pair1.pairLikelihood < pair2.pairLikelihood) {
-      -1
-    } else if (pair1.pairLikelihood > pair2.pairLikelihood) {
-      1
-    } else {
-      0
     }
   }
 }

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/HaplotypePair.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/HaplotypePair.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.avocado.algorithms.hmm
+
+import scala.math._
+import scala.Ordering
+
+object HaplotypePair {
+
+  /**
+   * Exponentiates two numbers by base of 10, adds together, takes base 10 log, and returns.
+   *
+   * @param x1 First digit to sum.
+   * @param x2 Second digit to sum.
+   * @return Sum of two digits after exponentation and logarithm.
+   *
+   * @see approxLogSumExp10
+   */
+  def exactLogSumExp10(x1: Double, x2: Double): Double = {
+    log10(pow(10.0, x1) + pow(10.0, x2))
+  }
+
+  /**
+   * Exponentiates two numbers by base of 10, adds together, takes base 10 log, and returns.
+   *
+   * @param x1 First digit to sum.
+   * @param x2 Second digit to sum.
+   * @return Sum of two digits after exponentation and logarithm.
+   *
+   * @see exactLogSumExp10
+   */
+  def approxLogSumExp10(x1: Double, x2: Double): Double = {
+    exactLogSumExp10(x1, x2)
+  }
+
+}
+
+/**
+ * Class for a pairing of two haplotypes.
+ *
+ * @param haplotype1 First haplotype of pair.
+ * @param haplotype2 Second haplotype of pair.
+ */
+class HaplotypePair(val haplotype1: Haplotype, val haplotype2: Haplotype, hmm: HMMAligner = new HMMAligner) {
+
+  lazy val hasVariants = haplotype1.hasVariants || haplotype2.hasVariants
+  lazy val pairLikelihood = scorePairLikelihood
+
+  override def toString(): String = {
+    haplotype1.sequence + ", " + haplotype2.sequence + ", " + ("%1.3f" format pairLikelihood)
+  }
+
+  /**
+   * Scores likelihood of two paired haplotypes and their alignment.
+   *
+   * @return Phred scaled likelihood.
+   */
+  def scorePairLikelihood: Double = {
+    val readsProb = haplotype1.perReadLikelihoods.zip(haplotype1.perReadLikelihoods).map(scores => HaplotypePair.exactLogSumExp10(scores._1, scores._2) - log10(2.0)).sum
+    val alignment = hmm.alignSequences(haplotype2.sequence, haplotype1.sequence, null)
+    readsProb + alignment.prior
+  }
+
+  val sequences: Set[String] = Set(haplotype1.sequence, haplotype2.sequence)
+
+  def sameSequences(other: HaplotypePair): Boolean = {
+    sequences == other.sequences
+  }
+
+}
+
+/**
+ * Haplotype pairs are ordered by increasing pairwise likelihood, assuming
+ *  they come from the same read group.
+ */
+object HaplotypePairOrdering extends Ordering[HaplotypePair] {
+
+  /**
+   * Compares two haplotype pairs. Returns (-1, 0, 1) if first pair has (lower, same, higher)
+   * pairwise likelihood.
+   *
+   * @param pair1 First haplotype pair to compare.
+   * @param pair2 Second haplotype pair to compare.
+   * @return Comparison of haplotype pairs.
+   */
+  def compare(pair1: HaplotypePair, pair2: HaplotypePair): Int = {
+    if (pair1.pairLikelihood < pair2.pairLikelihood) {
+      -1
+    } else {
+      1
+    }
+  }
+}

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/TransitionMatrix.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/TransitionMatrix.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.avocado.algorithms.hmm
+
+import scala.math._
+import org.bdgenomics.avocado.algorithms.hmm.AlignmentState._
+
+class TransitionMatrix(val LOG_GAP_OPEN: Double = -4.0,
+                       val LOG_GAP_CONTINUE: Double = -2.0,
+                       val LOG_SNP_RATE: Double = -3.0,
+                       val LOG_INDEL_RATE: Double = -4.0) {
+
+  var matSize = 0
+  var stride = 0
+  var matches = new Array[Double](matSize)
+  var inserts = new Array[Double](matSize)
+  var deletes = new Array[Double](matSize)
+
+  // P( match -> match) = 1 - 2 * P(match -> indel) = 1 - 2 * P( gap-open )
+  // in log-space
+  val LOG_MATCH_TO_MATCH = log10(1 - 2 * pow(10, LOG_GAP_OPEN))
+
+  // P( indel -> match) = 1 - P(indel -> indel) = 1 - P( gap-continue)
+  // in log-space
+  val LOG_GAP_CLOSE = log10(1 - pow(10, LOG_GAP_CONTINUE))
+
+  // P( match) = 1 - P(mismatch)
+  val MATCH_PROB = 1 - pow(10, LOG_SNP_RATE)
+
+  // in log-space
+  val LOG_MATCH_PROB = log10(MATCH_PROB)
+
+  /**
+   *
+   *  This creates a single backing transition matrix and only reallocates
+   *  the matrices if the length of the sequences has increased
+   *
+   */
+  def reallocate(rows: Int, columns: Int) = {
+    val newMatrixSize = rows * columns
+    stride = rows
+    if (newMatrixSize > matSize) {
+      matches = new Array[Double](newMatrixSize)
+      inserts = new Array[Double](newMatrixSize)
+      deletes = new Array[Double](newMatrixSize)
+    }
+
+    matSize = newMatrixSize
+    initialise(rows)
+  }
+
+  def getAlignmentLikelihood(): Double = {
+    max(matches(matSize - 1), max(inserts(matSize - 1), deletes(matSize - 1)))
+  }
+
+  def initialise(sequenceLength: Int) = {
+    matches(0) = 2 * log10(1.0 + sequenceLength)
+    inserts(0) = Double.NegativeInfinity
+    deletes(0) = Double.NegativeInfinity
+  }
+
+  def getMostLikelyState(idx: Int, epsilon: Double = 1e-2): AlignmentState = {
+    if (matches(idx) + epsilon >= inserts(idx) && matches(idx) + epsilon >= deletes(idx))
+      AlignmentState.Match
+    else if (inserts(idx) >= deletes(idx)) {
+      AlignmentState.Insertion
+    } else {
+      AlignmentState.Deletion
+    }
+  }
+
+  def getInsertionLikelihood(i: Int, j: Int, stride: Int): Double = {
+    if (i >= 1) {
+      val idx = (i - 1) * stride + j
+      max(gapProbability(AlignmentState.Insertion, idx), gapProbability(AlignmentState.Match, idx))
+    } else {
+      Double.NegativeInfinity
+    }
+  }
+
+  def getDeletionLikelihood(i: Int, j: Int, stride: Int): Double = {
+    if (j >= 1) {
+      val idx = i * stride + (j - 1)
+      max(gapProbability(AlignmentState.Deletion, idx), gapProbability(AlignmentState.Match, idx))
+    } else {
+      Double.NegativeInfinity
+    }
+  }
+
+  def getMatchLikelihood(i: Int, j: Int, stride: Int, refSequence: String, testSequence: String): Double = {
+    if (i >= 1 && j >= 1) {
+      val testBase = testSequence(i - 1)
+      val refBase = refSequence(j - 1)
+      val (emitProbability) = if (testBase == refBase) {
+        LOG_MATCH_PROB
+      } else {
+        LOG_SNP_RATE
+      }
+      val idx = (i - 1) * stride + (j - 1)
+      val p = AlignmentState.values.map(state => matchProbability(state, idx)).max + emitProbability
+      p
+    } else {
+      Double.NegativeInfinity
+    }
+  }
+
+  private def gapProbability(state: AlignmentState, idx: Int): Double = {
+    state match {
+      case AlignmentState.Insertion                       => inserts(idx) + LOG_GAP_CONTINUE
+      case AlignmentState.Deletion                        => deletes(idx) + LOG_GAP_CONTINUE
+      case AlignmentState.Match | AlignmentState.Mismatch => matches(idx) + LOG_GAP_OPEN
+    }
+  }
+
+  private def matchProbability(state: AlignmentState, idx: Int): Double = {
+    state match {
+      case AlignmentState.Insertion                       => inserts(idx) + LOG_GAP_CLOSE
+      case AlignmentState.Deletion                        => deletes(idx) + LOG_GAP_CLOSE
+      case AlignmentState.Match | AlignmentState.Mismatch => matches(idx) + LOG_MATCH_TO_MATCH
+    }
+  }
+}

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
@@ -87,7 +87,7 @@ class KmerGraphSuite extends SparkFunSuite {
     assert(graph.kmerSequences.toSet.contains("CCA"))
     assert(graph.kmerSequences.toSet.contains("CAA"))
 
-    assert(graph.allPaths.length === 1)
+    assert(graph.allPaths.size === 1)
     assert(graph.allPaths.head.haplotypeString === "TACCAAT")
     assert(graph.allPaths.head.weight === (reference.length - 2))
   }
@@ -129,7 +129,7 @@ class KmerGraphSuite extends SparkFunSuite {
     assert(kmerGraph.prefixSet.contains("TGT"))
     assert(kmerGraph.prefixSet.contains("GTA"))
 
-    assert(kmerGraph.allPaths.length === 1)
+    assert(kmerGraph.allPaths.size === 1)
     assert(kmerGraph.allPaths.head.haplotypeString === "TACCAATGTAA")
     // middle kmers are covered 4x, dropping off to 1x at ends
     assert(kmerGraph.allPaths.head.weight === (2 * 4 + 2 * 3 + 2 * 2 + 2 * 1))
@@ -177,8 +177,8 @@ class KmerGraphSuite extends SparkFunSuite {
     assert(kmerGraph.prefixSet.contains("TGT"))
     assert(kmerGraph.prefixSet.contains("GTA"))
 
-    assert(kmerGraph.allPaths.length === 4)
-    val haplotypes = kmerGraph.allPaths.map(_.haplotypeString).toSet
+    assert(kmerGraph.allPaths.size === 4)
+    val haplotypes = kmerGraph.allPaths.map(_.haplotypeString)
     assert(haplotypes.contains("TACCAATGTAA"))
     assert(haplotypes.contains("TACCCATGTAA"))
     assert(haplotypes.contains("TACCCAATGTAA"))
@@ -193,6 +193,6 @@ class KmerGraphSuite extends SparkFunSuite {
     val reference = rcap.getReference(reads)
 
     val kmerGraph = KmerGraph(20, 101, reference.length, reference, reads, 40)
-    assert(kmerGraph.allPaths.length === 30)
+    assert(kmerGraph.allPaths.size === 30)
   }
 }

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/hmm/HMMAlignerSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/hmm/HMMAlignerSuite.scala
@@ -1,0 +1,120 @@
+package org.bdgenomics.avocado.algorithms.hmm
+
+import org.scalatest.FunSuite
+
+class HMMAlignerSuite extends FunSuite {
+
+  test("test perfect match alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TCGATCGA"
+    val qualities = "FFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === false)
+    assert(alignment.alignmentStateSequence === "========")
+    assert(alignment.alignedReference === "TCGATCGA")
+    assert(alignment.alignedSequence === "TCGATCGA")
+
+  }
+
+  test("test single-snp alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TCGTTCGA"
+    val qualities = "FFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "===X====")
+    assert(alignment.alignedReference === "TCGATCGA")
+    assert(alignment.alignedSequence === "TCGTTCGA")
+  }
+
+  test("test multi-snp alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TGGATGGA"
+    val qualities = "FFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "=X===X==")
+    assert(alignment.alignedReference === "TCGATCGA")
+    assert(alignment.alignedSequence === "TGGATGGA")
+  }
+
+  test("test single insertion alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TCGAATCGA"
+    val qualities = "FFFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "===I=====")
+    assert(alignment.alignedReference === "TCG_ATCGA")
+    assert(alignment.alignedSequence === "TCGAATCGA")
+  }
+
+  test("test homopolymer single insertion alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TACCAATGTAA"
+    val testSequence = "TACCCAATGTAA"
+    val qualities = "FFFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "==I=========")
+    assert(alignment.alignedReference === "TA_CCAATGTAA")
+    assert(alignment.alignedSequence === "TACCCAATGTAA")
+  }
+
+  test("test long insertion alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TCGACCCCTCGA"
+    val qualities = "FFFFFFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "====IIII====")
+    assert(alignment.alignedReference === "TCGA____TCGA")
+    assert(alignment.alignedSequence === "TCGACCCCTCGA")
+  }
+
+  test("test single deletion alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TCGATGA"
+    val qualities = "FFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "=====D==")
+    assert(alignment.alignedReference === "TCGATCGA")
+    assert(alignment.alignedSequence === "TCGAT_GA")
+  }
+
+  test("test mixed insertion and deletion alignment") {
+    val hmm = new HMMAligner
+    val refSequence = "TCGATCGA"
+    val testSequence = "TCGAGGTCG"
+    val qualities = "FFFFFFFFFF"
+
+    val alignment = hmm.alignSequences(refSequence, testSequence, qualities)
+
+    assert(alignment.hasVariants === true)
+    assert(alignment.alignmentStateSequence === "====II===D")
+    assert(alignment.alignedReference === "TCGA__TCGA")
+    assert(alignment.alignedSequence === "TCGAGGTCG_")
+  }
+
+}

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/calls/reads/ReadCallAssemblySuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/calls/reads/ReadCallAssemblySuite.scala
@@ -16,16 +16,11 @@
 
 package org.bdgenomics.avocado.calls.reads
 
-import org.bdgenomics.adam.avro.{ ADAMContig, ADAMRecord, ADAMGenotypeAllele }
-import org.bdgenomics.adam.models.ADAMVariantContext
-import org.bdgenomics.avocado.algorithms.debrujin._
 import org.bdgenomics.avocado.algorithms.hmm._
-import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
 import org.scalatest.FunSuite
 import scala.collection.JavaConversions._
-import scala.collection.mutable.{ ArrayBuffer, Buffer, HashMap, HashSet, PriorityQueue, StringBuilder }
 import org.bdgenomics.adam.rich.RichADAMRecord
+import org.bdgenomics.adam.avro.{ ADAMGenotypeAllele, ADAMRecord, ADAMContig }
 
 class ReadCallAssemblySuite extends FunSuite {
 


### PR DESCRIPTION
Some notes:
- This causes some failing tests in ReadCallAssemblySuite which still needs to be looked into
- I only changed Haplotype and HaplotypePair so that they would still work, but I think we can probably do more there.
- Right now the transition matrix (to be renamed perhaps?) still follows the older strategy of allocating the likelihood matrices once and only reallocating if its need to make them bigger. I'm not sure how much this 
- I renamed some of the HMM parameters from <>Prior to openGapPenalty and closeGap, open to alternatives.
