### PR TITLE
Use function from ADAM to create reference sequence

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraph.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraph.scala
@@ -18,6 +18,7 @@ package org.bdgenomics.avocado.algorithms.debrujin
 
 import org.bdgenomics.adam.avro.ADAMRecord
 import scala.collection.mutable.{ ArrayBuffer, HashMap, HashSet, PriorityQueue }
+import org.bdgenomics.adam.rich.RichADAMRecord
 
 /**
  * For our purposes, a read is a list of kmers.
@@ -210,7 +211,7 @@ class KmerGraph(kLen: Int, readLen: Int, regionLen: Int, reference: String) {
    *
    * @param readGroup Sequence of reads to add.
    */
-  def insertReads(readGroup: Seq[ADAMRecord]): Unit = {
+  def insertReads(readGroup: Seq[RichADAMRecord]): Unit = {
     reads = readGroup.map(x => new AssemblyRead(x))
     reads.foreach(r => insertReadKmers(r))
   }

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Haplotype.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Haplotype.scala
@@ -4,6 +4,8 @@ import scala.collection.mutable.ArrayBuffer
 import org.bdgenomics.adam.avro.ADAMRecord
 import scala.math._
 import scala.math.Ordering
+import org.bdgenomics.adam.rich.RichADAMRecord
+
 /**
  * Haplotype generated from HMM alignment.
  *
@@ -22,7 +24,7 @@ class Haplotype(val sequence: String) {
    * @param reads Sequence of reads to use.
    * @return Likelihood that reads are properly aligned.
    */
-  def scoreReadsLikelihood(hmm: HMMAligner, reads: Seq[ADAMRecord]): Double = {
+  def scoreReadsLikelihood(hmm: HMMAligner, reads: Seq[RichADAMRecord]): Double = {
     perReadLikelihoods.clear
     readsLikelihood = 0.0
     for (r <- reads) {
@@ -133,7 +135,7 @@ class HaplotypePair(val haplotype1: Haplotype, val haplotype2: Haplotype) {
    * @param reads Sequence of reads that are evidence for haplotype.
    * @return Phred scaled likelihood.
    */
-  def scorePairLikelihood(hmm: HMMAligner, reads: Seq[ADAMRecord]): Double = {
+  def scorePairLikelihood(hmm: HMMAligner, reads: Seq[RichADAMRecord]): Double = {
     var readsProb = 0.0
     for (i <- 0 until reads.length) {
       val readLikelihood1 = haplotype1.perReadLikelihoods(i)

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/calls/reads/ReadCallAssemblySuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/calls/reads/ReadCallAssemblySuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.rdd.RDD
 import org.scalatest.FunSuite
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ ArrayBuffer, Buffer, HashMap, HashSet, PriorityQueue, StringBuilder }
+import org.bdgenomics.adam.rich.RichADAMRecord
 
 class ReadCallAssemblySuite extends FunSuite {
 
@@ -36,13 +37,13 @@ class ReadCallAssemblySuite extends FunSuite {
                 mdtag: String,
                 length: Int,
                 qualities: Seq[Int],
-                id: Int = 0): ADAMRecord = {
+                id: Int = 0): RichADAMRecord = {
 
     val contig = ADAMContig.newBuilder()
       .setContigName("chr1")
       .build()
 
-    ADAMRecord.newBuilder()
+    RichADAMRecord(ADAMRecord.newBuilder()
       .setReadName("read" + id.toString)
       .setStart(start)
       .setReadMapped(true)
@@ -54,7 +55,7 @@ class ReadCallAssemblySuite extends FunSuite {
       .setMismatchingPositions(mdtag)
       .setRecordGroupSample("sample")
       .setContig(contig)
-      .build()
+      .build())
   }
 
   test("Test the creation of several haplotype strings.") {


### PR DESCRIPTION
In ReadCallAssemblyCaller a function was written that creates a reference sequence, when a function for this exists in ADAM.  I've removed that function.

In doing so, many of the functions now take RichADAMRecord instead of ADAMRecord since we need to the conversion to access the mdTag (it was being done anyways, now it is just done explicitly upfront).
