### PR TITLE
Simplify haplotype queue creation

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/HMMAligner.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/HMMAligner.scala
@@ -45,8 +45,6 @@ class HMMAligner(val indelPrior: Double = -4.0,
 
   var testAligned: String = null
 
-  var refOffset = 0
-
   var matSize = 1
 
   private var matches: Array[Double] = Array(0.0)

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/calls/reads/ReadCallAssemblySuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/calls/reads/ReadCallAssemblySuite.scala
@@ -59,16 +59,12 @@ class ReadCallAssemblySuite extends FunSuite {
   }
 
   test("Test log sum for similar values") {
-    val hp = new HaplotypePair(null, null)
-    val sum = hp.exactLogSumExp10(1.0, 1.0)
-
+    val sum = HaplotypePair.exactLogSumExp10(1.0, 1.0)
     assert(1.3 * 0.99 < sum && 1.3 * 1.01 > sum)
   }
 
   test("Test log sum for dissimilar values") {
-    val hp = new HaplotypePair(null, null)
-    val sum = hp.exactLogSumExp10(1.0, -3.0)
-
+    val sum = HaplotypePair.exactLogSumExp10(1.0, -3.0)
     assert(1.00004342 * 0.99 < sum && 1.00004342 * 1.01 > sum)
   }
 


### PR DESCRIPTION
This is mostly to make the generation of the ordered haplotype and haplotype pairs easier, but it led to a few more changes.
- Move HaplotypePair math functions to static object
- Compute likelihoods on creation (this is to address issue #54, where a Haplotype pair created with haplotypes before calling .scoreLikelihoods on them would not get the correct likelihoods)
  (NOTE: For this each haplotype is currently instantiating its own HMMAligner.  HMMAligner currently requires functions to called in a certain order to get the right results, hopefully this will be handled by https://github.com/bigdatagenomics/avocado/pull/52 so that we can remove this.
- Additionally #52 will provide full alignment details rather than having a few individual field as Haplotype currently does.
