### PR TITLE
Get contig length from adamcontig

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/stats/GetReferenceContigLengths.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/stats/GetReferenceContigLengths.scala
@@ -29,7 +29,7 @@ private[stats] object GetReferenceContigLengths {
    * @return List of contig lengths.
    */
   def apply(rdd: RDD[ADAMNucleotideContigFragment]): Map[String, Long] = {
-    rdd.map(c => (c.getContig.getContigName.toString, c.getContigLength.toLong)).distinct.collect.toMap
+    rdd.map(c => (c.getContig.getContigName.toString, c.getContig.getContigLength.toLong)).distinct.collect.toMap
   }
 
 }


### PR DESCRIPTION
ADAMNucleotideFragment.contigLength is not set anymore, we can retrieve it from contig.contigLength
