### PR TITLE
Remove is<Type> methods from variantcall

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/VariantCall.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/VariantCall.scala
@@ -75,8 +75,6 @@ abstract class VariantCall extends Serializable with Logging {
 
   def call(rdd: RDD[ADAMRecord]): RDD[ADAMVariantContext]
 
-  def isReadCall(): Boolean
-  def isPileupCall(): Boolean
   def isCallable(): Boolean
 }
 

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/pileup/PileupCall.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/pileup/PileupCall.scala
@@ -48,7 +48,4 @@ abstract class PileupCall extends VariantCall {
     val rods = reads.adamRecords2Rods()
     callRods(rods)
   }
-
-  override def isReadCall(): Boolean = false
-  override def isPileupCall(): Boolean = true
 }

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/reads/ReadCall.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/calls/reads/ReadCall.scala
@@ -35,7 +35,5 @@ abstract class ReadCall extends VariantCall {
    */
   def call(pileupGroups: RDD[ADAMRecord]): RDD[ADAMVariantContext]
 
-  override def isReadCall(): Boolean = true
-  override def isPileupCall(): Boolean = false
 }
 


### PR DESCRIPTION
The VariantCaller type should be derivable from the class type and these are currently not used.
