### PR TITLE
Refactoring transition matrix to allow for cleaner configuration

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Haplotype.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/Haplotype.scala
@@ -25,7 +25,11 @@ import scala.math._
  *
  * @param sequence String representing haplotype alignment.
  */
-class Haplotype(val sequence: String, region: Seq[RichADAMRecord], hmm: HMMAligner = new HMMAligner, val reference: String = "") {
+class Haplotype(val sequence: String,
+                region: Seq[RichADAMRecord],
+                hmm: HMMAligner = new HMMAligner,
+                val reference: String = "",
+                readAlignerConfig: TransitionMatrixConfiguration = TransitionMatrixConfiguration()) {
 
   def reg: String = {
     val start = region.map(_.getStart).min
@@ -45,7 +49,7 @@ class Haplotype(val sequence: String, region: Seq[RichADAMRecord], hmm: HMMAlign
   lazy val perReadLikelihoods: Seq[Double] = {
     region.map(read => {
       try {
-        val alignment = HMMAligner.align(sequence, read.getSequence.toString, null)
+        val alignment = HMMAligner.align(sequence, read.getSequence.toString, null, readAlignerConfig)
         alignment.likelihood + alignment.prior
       } catch {
         case _: Throwable => {

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/TransitionMatrix.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/algorithms/hmm/TransitionMatrix.scala
@@ -16,8 +16,39 @@
 
 package org.bdgenomics.avocado.algorithms.hmm
 
-import scala.math._
+import org.apache.commons.configuration.SubnodeConfiguration
 import org.bdgenomics.avocado.algorithms.hmm.AlignmentState._
+import scala.math._
+
+object TransitionMatrixConfiguration {
+
+  def apply(config: SubnodeConfiguration): TransitionMatrixConfiguration = {
+    new TransitionMatrixConfiguration(config.getDouble("LOG_GAP_OPEN"),
+      config.getDouble("LOG_GAP_CONTINUE"),
+      config.getDouble("LOG_SNP_RATE"),
+      config.getDouble("LOG_INDEL_RATE"),
+      config.getDouble("LOG_PADDING_PENALTY"))
+  }
+
+}
+
+case class TransitionMatrixConfiguration(LOG_GAP_OPEN: Double = -4.0,
+                                         LOG_GAP_CONTINUE: Double = -2.0,
+                                         LOG_SNP_RATE: Double = -3.0,
+                                         LOG_INDEL_RATE: Double = -4.0,
+                                         LOG_PADDING_PENALTY: Double = -0.0) extends Serializable {
+}
+
+object TransitionMatrix {
+
+  def apply(config: TransitionMatrixConfiguration): TransitionMatrix = {
+    new TransitionMatrix(config.LOG_GAP_OPEN,
+      config.LOG_GAP_CONTINUE,
+      config.LOG_SNP_RATE,
+      config.LOG_INDEL_RATE,
+      config.LOG_PADDING_PENALTY)
+  }
+}
 
 class TransitionMatrix(val LOG_GAP_OPEN: Double = -4.0,
                        val LOG_GAP_CONTINUE: Double = -2.0,

--- a/avocado-sample-configs/assembler.properties
+++ b/avocado-sample-configs/assembler.properties
@@ -5,7 +5,25 @@
 
   assembler = 
   {
-    lowCoverageTrimmingThreshold = 0.1
+    lowCoverageTrimmingThreshold = 0.1;
+
+    haplotypeAligner =
+    {
+      LOG_GAP_OPEN = -4.0;
+      LOG_GAP_CONTINUE = -2.0;
+      LOG_SNP_RATE = -3.0;
+      LOG_INDEL_RATE = -4.0;
+      LOG_PADDING_PENALTY = -0.0;
+    }
+
+    readAligner =
+    {
+      LOG_GAP_OPEN = -100.0;
+      LOG_GAP_CONTINUE = -100.0;
+      LOG_SNP_RATE = -1.7;
+      LOG_INDEL_RATE = -100.0;
+      LOG_PADDING_PENALTY = -0.0;
+    }
   }
   defPart = 
   {

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <name>avocado: A Variant Caller, Distributed</name>
 
   <properties>
-    <adam.version>0.9.1-SNAPSHOT</adam.version>
+    <adam.version>0.10.0</adam.version>
     <avro.version>1.7.4</avro.version>
     <java.version>1.6</java.version>
     <scala.version>2.10.3</scala.version>


### PR DESCRIPTION
Modifies transition matrix code to add a case class for config. Additionally, this new configurability is propagated back into the HMM aligner and assembler code. Specifically, we modify the Haplotype class to support the use of different aligners for aligning haplotypes against the reference genome, and for aligning reads against haplotypes.

The big significance of this last change is that sequencer error models can be incorporated into the haplotype clustering model. In the default assembler config, we now provide a generic Illumina error model for the read aligner.
