### PR TITLE
[avocado-98] Add somatic genotyper

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/discovery/Explore.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/discovery/Explore.scala
@@ -25,7 +25,8 @@ import org.bdgenomics.formats.avro.AlignmentRecord
 
 object Explore {
 
-  val explorers: Seq[ExplorerCompanion] = Seq(ReadExplorer)
+  val explorers: Seq[ExplorerCompanion] = Seq(ReadExplorer,
+    ExternalExplorer)
 
   def apply(explorerAlgorithm: String,
             explorerName: String,

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/BiallelicGenotyper.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/BiallelicGenotyper.scala
@@ -118,7 +118,7 @@ class BiallelicGenotyper(ploidy: Int = 2,
                               idx: Int = 1,
                               maxIdx: Int = 0): Int = {
     // are we at the end of the array? if so, return.
-    if (idx > array.length) {
+    if (idx >= array.length) {
       maxIdx
     } else {
       // do we have a new max? if so, update the current max index.

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/CallGenotypes.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/CallGenotypes.scala
@@ -26,7 +26,8 @@ import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 object CallGenotypes {
 
   val genotypers: Seq[GenotyperCompanion] = Seq(BiallelicGenotyper,
-    ExternalGenotyper)
+    ExternalGenotyper,
+    SomaticGenotyper)
 
   def apply(genotyperAlgorithm: String,
             genotyperName: String,

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/SomaticGenotyper.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/SomaticGenotyper.scala
@@ -1,0 +1,132 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.genotyping
+
+import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
+import org.apache.spark.Logging
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.{ ReferencePosition, VariantContext }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.util.PhredUtils
+import org.bdgenomics.avocado.models.{ AlleleObservation, Observation }
+import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
+import org.bdgenomics.formats.avro.{ Contig, Genotype, GenotypeAllele, Variant }
+import scala.annotation.tailrec
+import scala.math.pow
+
+object SomaticGenotyper extends GenotyperCompanion {
+
+  val genotyperName: String = "SomaticGenotyper"
+
+  protected def apply(stats: AvocadoConfigAndStats,
+                      config: SubnodeConfiguration): Genotyper = {
+
+    new SomaticGenotyper(config.getString("normalSample"),
+      config.getString("somaticSample"),
+      config.getInt("normalPloidy", 2))
+  }
+}
+
+class SomaticGenotyper(normalSample: String,
+                       somaticSample: String,
+                       normalPloidy: Int = 2) extends Genotyper with Logging {
+
+  val companion: GenotyperCompanion = SomaticGenotyper
+
+  protected val bg = new BiallelicGenotyper(normalPloidy)
+
+  def genotypeSite(site: (ReferencePosition, Iterable[Observation])): Iterable[VariantContext] = {
+    val (pos, observations) = site
+
+    // get reference allele
+    val reference = observations.find(obs => obs match {
+      case ao: AlleleObservation => false
+      case _                     => true
+    }).fold({
+      log.info("Had alleles observed, but no reference at " + pos)
+      return None
+    })(_.allele)
+
+    // get allele observations
+    val alleleObservations: Iterable[AlleleObservation] = observations.flatMap(obs => obs match {
+      case ao: AlleleObservation => Some(ao)
+      case _                     => None
+    })
+
+    // split out normal and somatic sample observations
+    val normalObservations = alleleObservations.filter(_.sample == normalSample)
+    val somaticObservations = alleleObservations.filter(_.sample == somaticSample)
+
+    // get most frequently observed non-ref allele from normal sample
+    val nonRefAlleles = normalObservations.filter(_.allele != reference)
+    val allele = if (nonRefAlleles.size > 0) {
+      nonRefAlleles.groupBy(_.allele)
+        .maxBy(kv => kv._2.size)
+        ._1
+    } else {
+      "N" // we need a non-reference allele for calculating genotype likelihoods
+    }
+
+    // calculate site genotype likelihoods for the normal sample
+    val (_, normalLikelihoods, _) = bg.scoreGenotypeLikelihoods(reference,
+      allele,
+      normalObservations)
+    val normalGenotype = bg.idxOfMax(normalLikelihoods)
+
+    // calculate somatic depth
+    val somaticDepth = somaticObservations.size
+
+    // find alleles in somatic sample
+    val somaticAlleleObservations = somaticObservations.filter(obs => {
+      !(normalGenotype != 0 && obs.allele == reference) &&
+        !(normalGenotype != 2 && obs.allele == allele)
+    }).groupBy(_.allele)
+
+    // emit calls
+    somaticAlleleObservations.map(kv => {
+      val (allele, obs) = kv
+
+      // emit variant
+      val variant = Variant.newBuilder()
+        .setReferenceAllele(reference)
+        .setAlternateAllele(allele)
+        .setContig(Contig.newBuilder()
+          .setContigName(pos.referenceName)
+          .build())
+        .setStart(pos.pos)
+        .setEnd(pos.pos + reference.length)
+        .build()
+
+      // emit genotype - not sure what to do about genotype state...
+      val genotype = Genotype.newBuilder()
+        .setVariant(variant)
+        .setSampleId(somaticSample)
+        .setReadDepth(somaticDepth)
+        .setAlternateReadDepth(obs.size)
+        .setGenotypeQuality(obs.map(o => (o.phred + o.mapq) / 2).sum)
+        .build()
+
+      VariantContext(variant, Iterable(genotype), None)
+    })
+  }
+
+  def genotype(observations: RDD[Observation]): RDD[VariantContext] = {
+    observations.groupBy(_.pos)
+      .flatMap(genotypeSite)
+  }
+}

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/genotyping/SomaticGenotyperSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/genotyping/SomaticGenotyperSuite.scala
@@ -1,0 +1,309 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.genotyping
+
+import org.bdgenomics.adam.models.{ ReferencePosition, VariantContext }
+import org.bdgenomics.avocado.models.{ Observation, AlleleObservation }
+import org.scalatest.FunSuite
+import scala.collection.JavaConversions._
+import scala.math.{ abs, sqrt }
+
+class SomaticGenotyperSuite extends FunSuite {
+  val sg = new SomaticGenotyper("normalSample", "somaticSample")
+
+  test("don't call a variant with a hom-ref normal and hom-ref somatic") {
+    val observed = Iterable(
+      new Observation(ReferencePosition("ctg", 0L), "C"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        40,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        40,
+        40,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        40,
+        true,
+        "somaticSample"))
+
+    val call = sg.genotypeSite((ReferencePosition("ctg", 0L), observed))
+
+    assert(call.size === 0)
+  }
+
+  test("call variant for hom-ref normal, \"hom-alt\" somatic") {
+    val observed = Iterable(
+      new Observation(ReferencePosition("ctg", 0L), "C"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        40,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        30,
+        30,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        40,
+        40,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        30,
+        40,
+        true,
+        "somaticSample"))
+
+    val call = sg.genotypeSite((ReferencePosition("ctg", 0L), observed))
+
+    assert(call.size === 1)
+    assert(call.head.variant.getAlternateAllele === "A")
+    assert(call.head.genotypes.size === 1)
+    assert(call.head.genotypes.head.getSampleId === "somaticSample")
+    assert(call.head.genotypes.head.getGenotypeQuality === 105)
+    assert(call.head.genotypes.head.getReadDepth === 3)
+    assert(call.head.genotypes.head.getAlternateReadDepth === 3)
+  }
+
+  test("don't call a variant for matching het normal and somatic") {
+    val observed = Iterable(
+      new Observation(ReferencePosition("ctg", 0L), "C"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        40,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        30,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        40,
+        40,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        30,
+        40,
+        true,
+        "somaticSample"))
+
+    val call = sg.genotypeSite((ReferencePosition("ctg", 0L), observed))
+
+    assert(call.size === 0)
+  }
+
+  test("call a variant for het normal and tri-allelic somatic") {
+    val observed = Iterable(
+      new Observation(ReferencePosition("ctg", 0L), "C"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        40,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        30,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        40,
+        40,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "T",
+        30,
+        40,
+        true,
+        "somaticSample"))
+
+    val call = sg.genotypeSite((ReferencePosition("ctg", 0L), observed))
+
+    assert(call.size === 1)
+    assert(call.head.variant.getAlternateAllele === "T")
+    assert(call.head.genotypes.size === 1)
+    assert(call.head.genotypes.head.getSampleId === "somaticSample")
+    assert(call.head.genotypes.head.getGenotypeQuality === 35)
+    assert(call.head.genotypes.head.getReadDepth === 3)
+    assert(call.head.genotypes.head.getAlternateReadDepth === 1)
+  }
+
+  test("call two variants for hom-ref normal and tri-allelic somatic") {
+    val observed = Iterable(
+      new Observation(ReferencePosition("ctg", 0L), "C"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        40,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        40,
+        true,
+        "normalSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "C",
+        30,
+        30,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "A",
+        40,
+        40,
+        true,
+        "somaticSample"),
+      AlleleObservation(ReferencePosition("ctg", 0L),
+        1,
+        "T",
+        30,
+        40,
+        true,
+        "somaticSample"))
+
+    val call = sg.genotypeSite((ReferencePosition("ctg", 0L), observed))
+
+    assert(call.size === 2)
+    assert(call.filter(_.variant.getAlternateAllele == "A").size === 1)
+    assert(call.filter(_.variant.getAlternateAllele == "T").size === 1)
+    assert(call.filter(_.variant.getAlternateAllele == "A").head.variant.getAlternateAllele === "A")
+    assert(call.filter(_.variant.getAlternateAllele == "A").head.genotypes.size === 1)
+    assert(call.filter(_.variant.getAlternateAllele == "A").head.genotypes.head.getSampleId === "somaticSample")
+    assert(call.filter(_.variant.getAlternateAllele == "A").head.genotypes.head.getGenotypeQuality === 40)
+    assert(call.filter(_.variant.getAlternateAllele == "A").head.genotypes.head.getReadDepth === 3)
+    assert(call.filter(_.variant.getAlternateAllele == "A").head.genotypes.head.getAlternateReadDepth === 1)
+    assert(call.filter(_.variant.getAlternateAllele == "T").head.variant.getAlternateAllele === "T")
+    assert(call.filter(_.variant.getAlternateAllele == "T").head.genotypes.size === 1)
+    assert(call.filter(_.variant.getAlternateAllele == "T").head.genotypes.head.getSampleId === "somaticSample")
+    assert(call.filter(_.variant.getAlternateAllele == "T").head.genotypes.head.getGenotypeQuality === 35)
+    assert(call.filter(_.variant.getAlternateAllele == "T").head.genotypes.head.getReadDepth === 3)
+    assert(call.filter(_.variant.getAlternateAllele == "T").head.genotypes.head.getAlternateReadDepth === 1)
+  }
+}


### PR DESCRIPTION
Closes #98 by adding a simple somatic genotyper. This uses the biallelic genotyping model to call variants in the normal sample, and then uses a VarScan style approach to call somatic variants. This is a pretty rough approach and will need further refinement.

CC'ing @tdanford for review.
