### PR TITLE
[avocado-109] Fix serialization-based unit test failure.

### DIFF
--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
@@ -28,6 +28,11 @@ import scala.collection.mutable.ArrayBuffer
 
 class KmerGraphSuite extends SparkFunSuite {
 
+  override val properties = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
+    ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),
+    ("spark.kryoserializer.buffer.mb", "128"),
+    ("spark.kryo.referenceTracking", "true"))
+
   // shamelessly borrowed from the indel realigner while we are refactoring...
   def getReferenceFromReads(reads: Seq[RichAlignmentRecord]): String = {
     // get reference and range from a single read

--- a/bin/avocado-spark-defaults.conf
+++ b/bin/avocado-spark-defaults.conf
@@ -16,5 +16,5 @@
 
 spark.serializer               org.apache.spark.serializer.KryoSerializer
 spark.kryo.registrator         org.bdgenomics.adam.serialization.ADAMKryoRegistrator
-spark.kryoserializer.buffer.mb 4
+spark.kryoserializer.buffer.mb 16
 spark.kryo.referenceTracking   true


### PR DESCRIPTION
Builds off of an upstream change (https://github.com/bigdatagenomics/adam/pull/394) to fix a serialization buffer overrun that was occurring in a single unit test.
