### PR TITLE
[avocado-112] Fixing ADAM-prefixed dependencies.

### DIFF
--- a/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/Avocado.scala
+++ b/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/Avocado.scala
@@ -38,7 +38,7 @@ import org.bdgenomics.adam.cli.{
 }
 import org.bdgenomics.adam.models.{ VariantContext, ReferenceRegion }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext
 import org.bdgenomics.avocado.discovery.Explore
 import org.bdgenomics.avocado.genotyping.CallGenotypes
 import org.bdgenomics.avocado.input.Input
@@ -140,7 +140,8 @@ class Avocado(protected val args: AvocadoArgs) extends ADAMSparkCommand[AvocadoA
   /**
    * Applies variant calling algorithms to reads and pileups. Reduces down and returns called variants.
    *
-   * @param callsets Map containing read calling algorithm and RDD record pairs.
+   * @param reads
+   * @param stats
    * @return Joined output of variant calling algorithms.
    */
   def callVariants(reads: RDD[AlignmentRecord], stats: AvocadoConfigAndStats): RDD[VariantContext] = {
@@ -189,7 +190,7 @@ class Avocado(protected val args: AvocadoArgs) extends ADAMSparkCommand[AvocadoA
     log.info("Starting avocado...")
 
     // load in reference from ADAM file
-    val reference: RDD[NucleotideContigFragment] = new ADAMNucleotideContigFragmentContext(sc)
+    val reference: RDD[NucleotideContigFragment] = new NucleotideContigFragmentContext(sc)
       .adamSequenceLoad(args.referenceInput, args.fragmentLength)
 
     log.info("Loading reads in from " + args.readInput)

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/discovery/ReadExplorer.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/discovery/ReadExplorer.scala
@@ -131,7 +131,7 @@ class ReadExplorer(referenceObservations: RDD[Observation]) extends Explorer wit
         case CigarOperator.S => {
           readPos += cigar(i).getLength
         }
-        case CigarOperator.H => 
+        case CigarOperator.H =>
         case _ => {
           if (cigar(i).getOperator.consumesReferenceBases) {
             pos += cigar(i).getLength

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/ExternalGenotyper.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/ExternalGenotyper.scala
@@ -31,7 +31,7 @@ import org.bdgenomics.adam.converters.VariantContextConverter
 import org.bdgenomics.adam.models.{ SAMFileHeaderWritable, VariantContext => ADAMVariantContext, ReferencePosition }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.GenomicRegionPartitioner
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.avocado.models.{ Observation, ReadObservation }
 import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 import htsjdk.variant.variantcontext.{ VariantContext => BroadVariantContext }

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/input/AlignedReadsInputStage.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/input/AlignedReadsInputStage.scala
@@ -21,8 +21,8 @@ import org.bdgenomics.formats.avro.{ AlignmentRecord, NucleotideContigFragment }
 import org.bdgenomics.adam.predicates.UniqueMappedReadPredicate
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMContext
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/input/Input.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/input/Input.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.avocado.input
 
 import org.bdgenomics.formats.avro.{ AlignmentRecord, NucleotideContigFragment }
-import org.apache.commons.configuration.{ HierarchicalConfiguration, SubnodeConfiguration }
+import org.apache.commons.configuration.HierarchicalConfiguration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -32,9 +32,10 @@ object Input {
    * that the stage provides. The input stage name to use is collected from the provided
    * configuration.
    *
+   * @param sc A SparkContext
    * @param inputPath Path to input read data.
+   * @param reference
    * @param config Configuration file containing the necessary data.
-   * @param stats Global stat and configuration data.
    * @return Returns an RDD of read data.
    */
   def apply(sc: SparkContext,

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/input/SnapInputStage.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/input/SnapInputStage.scala
@@ -30,7 +30,7 @@ import org.bdgenomics.formats.avro.{ AlignmentRecord, NucleotideContigFragment }
 import org.bdgenomics.adam.converters.SAMRecordConverter
 import org.bdgenomics.adam.io.InterleavedFastqInputFormat
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext._
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext._
 import org.bdgenomics.adam.models.{ RecordGroup, RecordGroupDictionary, SequenceDictionary }
 import org.bdgenomics.avocado.stats.AvocadoConfigAndStats
 import htsjdk.samtools._

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/MarkDuplicates.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/MarkDuplicates.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.avocado.preprocessing
 import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 object MarkDuplicates extends PreprocessingStage {

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/RealignIndels.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/RealignIndels.scala
@@ -21,7 +21,7 @@ import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 
 object RealignIndels extends PreprocessingStage {
 

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/RecalibrateBaseQualities.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/RecalibrateBaseQualities.scala
@@ -22,7 +22,7 @@ import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 object RecalibrateBaseQualities extends PreprocessingStage {

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/SortReads.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/SortReads.scala
@@ -21,7 +21,7 @@ import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 
 object SortReads extends PreprocessingStage {
 

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/stats/AvocadoConfigAndStats.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/stats/AvocadoConfigAndStats.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext._
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext._
 import org.bdgenomics.formats.avro.{ AlignmentRecord, NucleotideContigFragment }
 
 class AvocadoConfigAndStats(val sc: SparkContext,


### PR DESCRIPTION
Fixes #112, by updating the names of the ADAM-prefixed classes from the
adam repo that avocado depends on here.
