### PR TITLE
[avocado-125] Move to new alignment loader.

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/input/AlignedReadsInputStage.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/input/AlignedReadsInputStage.scala
@@ -46,7 +46,7 @@ private[input] object AlignedReadsInputStage extends InputStage {
 
     println("Loading reads in from " + inputPath)
 
-    new ADAMContext(sc).adamLoad(inputPath, Some(classOf[UniqueMappedReadPredicate]))
+    new ADAMContext(sc).loadAlignments(inputPath, Some(classOf[UniqueMappedReadPredicate]))
   }
 
 }

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
@@ -59,13 +59,13 @@ class KmerGraphSuite extends SparkFunSuite {
 
   def na12878_chr20_snp_reads: RDD[RichAlignmentRecord] = {
     val path = ClassLoader.getSystemClassLoader.getResource("NA12878_snp_A2G_chr20_225058.sam").getFile
-    val reads: RDD[AlignmentRecord] = sc.adamLoad(path)
+    val reads: RDD[AlignmentRecord] = sc.loadAlignments(path)
     reads.map(r => RichAlignmentRecord(r))
   }
 
   def more_na12878_chr20_snp_reads: RDD[RichAlignmentRecord] = {
     val path = ClassLoader.getSystemClassLoader.getResource("NA12878_snp_A2G_chr20_225058_longer.sam").getFile
-    val reads: RDD[AlignmentRecord] = sc.adamLoad(path)
+    val reads: RDD[AlignmentRecord] = sc.loadAlignments(path)
     reads.map(r => RichAlignmentRecord(r))
   }
 


### PR DESCRIPTION
Resolves #125. Moves to the alignment loader introduced in https://github.com/bigdatagenomics/adam/pull/468.
