### PR TITLE
Fixing upstream issue (#144): avocado should use bdg-utils-metrics version 0.1.3 instead of version 0.1.2 which is missing in sonatype repo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <spark.version>1.2.0</spark.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
-    <utils.version>0.1.2-SNAPSHOT</utils.version>
+    <utils.version>0.1.3-SNAPSHOT</utils.version>
   </properties>
   
   <modules>


### PR DESCRIPTION
See:
https://github.com/bigdatagenomics/avocado/issues/144