### PR TITLE
Fix BQSR SNP table loading

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/RecalibrateBaseQualities.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/RecalibrateBaseQualities.scala
@@ -22,6 +22,7 @@ import org.apache.commons.configuration.SubnodeConfiguration
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 object RecalibrateBaseQualities extends PreprocessingStage {
@@ -33,7 +34,7 @@ object RecalibrateBaseQualities extends PreprocessingStage {
     val sc = rdd.sparkContext
     // check for snp table
     val snpTable = if (config.containsKey("snpTable")) {
-      sc.broadcast(SnpTable(new File(config.getString("snpTable"))))
+      sc.broadcast(SnpTable(sc.loadVariants(config.getString("snpTable")).map(new RichVariant(_))))
     } else {
       sc.broadcast(SnpTable())
     }


### PR DESCRIPTION
Resolves #150. Load variants for BQSR through `sc.loadVariants`, instead of using the `SnpTable(file: java.io.File)` method.