### PR TITLE
Fixing build broken by ADAM #717.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <spark.version>1.2.0</spark.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
-    <utils.version>0.2.1</utils.version>
+    <utils.version>0.2.2</utils.version>
   </properties>
   
   <modules>


### PR DESCRIPTION
https://github.com/bigdatagenomics/adam/pull/717 moved to Parquet 1.7.0, which renamed the Parquet packages. This PR applies this change to avocado.