### PR TITLE
Upgrade to Spark 1.4, upgrade config for YARN

### DIFF
--- a/avocado-cli/pom.xml
+++ b/avocado-cli/pom.xml
@@ -134,6 +134,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-core_2.10</artifactId>
     </dependency>

--- a/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/Avocado.scala
+++ b/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/Avocado.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.avocado.cli
 
+import java.nio.file.Files
 import org.apache.commons.configuration.HierarchicalConfiguration
 import org.apache.commons.configuration.plist.PropertyListConfiguration
 import org.apache.hadoop.mapreduce.Job
@@ -83,8 +84,14 @@ class Avocado(protected val args: AvocadoArgs) extends BDGSparkCommand[AvocadoAr
   // companion object to this class - needed for BDGCommand framework
   val companion = Avocado
 
-  // get config
-  val config: HierarchicalConfiguration = new PropertyListConfiguration(args.configFile)
+  // get config off classpath and load into a temp file...
+  val stream = Thread.currentThread.getContextClassLoader.getResourceAsStream(args.configFile)
+  val tempPath = Files.createTempDirectory("config")
+  val tempFilePath = tempPath.resolve("temp.properties")
+  Files.copy(stream, tempFilePath)
+
+  // load config
+  val config: HierarchicalConfiguration = new PropertyListConfiguration(tempFilePath.toFile)
 
   val preprocessorNames = getStringArrayFromConfig("preprocessorNames")
   val preprocessorAlgorithms = getStringArrayFromConfig("preprocessorAlgorithms")

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/AvocadoFunSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/AvocadoFunSuite.scala
@@ -23,8 +23,6 @@ trait AvocadoFunSuite extends SparkFunSuite {
 
   override val appName: String = "avocado"
   override val properties: Map[String, String] = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
-    ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),
-    ("spark.kryoserializer.buffer.mb", "4"),
-    ("spark.kryo.referenceTracking", "true"))
+    ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"))
 }
 

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/algorithms/debrujin/KmerGraphSuite.scala
@@ -29,9 +29,7 @@ import scala.collection.mutable.ArrayBuffer
 class KmerGraphSuite extends AvocadoFunSuite {
 
   override val properties = Map(("spark.serializer", "org.apache.spark.serializer.KryoSerializer"),
-    ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"),
-    ("spark.kryoserializer.buffer.mb", "128"),
-    ("spark.kryo.referenceTracking", "true"))
+    ("spark.kryo.registrator", "org.bdgenomics.adam.serialization.ADAMKryoRegistrator"))
 
   // shamelessly borrowed from the indel realigner while we are refactoring...
   def getReferenceFromReads(reads: Seq[RichAlignmentRecord]): String = {

--- a/bin/avocado-submit
+++ b/bin/avocado-submit
@@ -57,13 +57,37 @@ AVOCADO_JARS=$("$AVOCADO_REPO"/bin/compute-avocado-jars.sh)
 AVOCADO_CLI_JAR=${AVOCADO_JARS##*,}
 AVOCADO_JARS=$(echo "$AVOCADO_JARS" | rev | cut -d',' -f2- | rev)
 
+# do we have >= 4 arguments? if so, magic!!!!!!!
+if [ ${#AVOCADO_ARGS[@]} -ge 4 ]; then
+    # make a temp directory
+    TEMP_DIR=$(mktemp -d -t "avocado.properties.XXXXXXXX")
+    DIR_ID=${TEMP_DIR##*.}
+
+    # copy property file over
+    cp ${AVOCADO_ARGS[3]} "${TEMP_DIR}/${DIR_ID}.properties"
+
+    # make jar
+    jar cf "${TEMP_DIR}/${DIR_ID}.jar" -C ${TEMP_DIR} ${DIR_ID}.properties
+    cp "${TEMP_DIR}/${DIR_ID}.jar" .
+
+    # add jar to classpath
+    AVOCADO_JARS="${AVOCADO_JARS},${TEMP_DIR}/${DIR_ID}.jar"
+
+    # modify arguments
+    AVOCADO_ARGS[3]="${DIR_ID}.properties"
+fi
+
 # Find spark-submit script
 if [ -z "$SPARK_HOME" ]; then
-  echo "Attempting to use 'spark-submit' on default path; you might need to set SPARK_HOME"
-  SPARK_SUBMIT=spark-submit
+  SPARK_SUBMIT=$(which spark-submit)
 else
   SPARK_SUBMIT="$SPARK_HOME"/bin/spark-submit
 fi
+if [ -z "$SPARK_SUBMIT" ]; then
+  echo "SPARK_HOME not set and spark-submit not on PATH; Aborting."
+  exit 1
+fi
+echo "Using SPARK_SUBMIT=$SPARK_SUBMIT"
 
 # submit the job to Spark
 "$SPARK_SUBMIT" \

--- a/bin/avocado-submit
+++ b/bin/avocado-submit
@@ -17,28 +17,47 @@
 # limitations under the License.
 #
 
+set -e
+
+# Split args into Spark and ADAM args
+DD=False  # DD is "double dash"
+PRE_DD=()
+POST_DD=()
+for ARG in "$@"; do
+  shift
+  if [[ $ARG == "--" ]]; then
+    DD=True
+    POST_DD=( "$@" )
+    break
+  fi
+  PRE_DD+=("$ARG")
+done
+
+if [[ $DD == True ]]; then
+  SPARK_ARGS="${PRE_DD[@]}"
+  AVOCADO_ARGS=("${POST_DD[@]}")
+else
+  SPARK_ARGS=()
+  AVOCADO_ARGS=(${PRE_DD[@]})
+fi
+
+# does the user have AVOCADO_OPTS set? if yes, then warn
+if [[ $DD == False && -n "$AVOCADO_OPTS" ]]; then
+    echo "WARNING: Passing Spark arguments via AVOCADO_OPTS was recently removed."
+    echo "Run avocado-submit instead as avocado-submit <spark-args> -- <avocado-args>"
+fi
+
 # Figure out where AVOCADO is installed
 AVOCADO_REPO="$(cd `dirname $0`/..; pwd)"
 
 CLASSPATH=$("$AVOCADO_REPO"/bin/compute-avocado-classpath.sh)
 AVOCADO_JARS=$("$AVOCADO_REPO"/bin/compute-avocado-jars.sh)
 
-# Find the AVOCADO CLI jar
-num_versions=$(ls "$AVOCADO_REPO"/avocado-cli/target/appassembler/repo/org/bdgenomics/avocado/avocado-cli | wc -l)
-if [ "$num_versions" -eq "0" ]; then
-  echo "Failed to find avocado-cli jar in $AVOCADO_REPO/avocado-cli/target/appassembler/repo/org/bdgenomics/avocado/avocado-cli"
-  echo "You need to build avocado before running this program."
-  exit 1
-fi
-if [ "$num_versions" -gt "1" ]; then
-  versions_list=$(ls "$AVOCADO_REPO"/avocado-cli/target/appassembler/repo/org/bdgenomics/avocado/avocado-cli)
-  echo "Found multiple avocado CLI versions in $AVOCADO_REPO/avocado-cli/target/appassembler/repo/org/bdgenomics/avocado/avocado-cli:"
-  echo "$versions_list"
-  echo "Please remove all but one."
-  exit 1
-fi
-AVOCADO_CLI_JAR=$(ls "$AVOCADO_REPO"/avocado-cli/target/appassembler/repo/org/bdgenomics/avocado/avocado-cli/*/avocado-cli-*.jar)
+# Split out the CLI jar, since it will be passed to Spark as the "primary resource".
+AVOCADO_CLI_JAR=${AVOCADO_JARS##*,}
+AVOCADO_JARS=$(echo "$AVOCADO_JARS" | rev | cut -d',' -f2- | rev)
 
+# Find spark-submit script
 if [ -z "$SPARK_HOME" ]; then
   echo "Attempting to use 'spark-submit' on default path; you might need to set SPARK_HOME"
   SPARK_SUBMIT=spark-submit
@@ -51,11 +70,7 @@ fi
   --class org.bdgenomics.avocado.cli.Avocado \
   --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
   --conf spark.kryo.registrator=org.bdgenomics.adam.serialization.ADAMKryoRegistrator \
-  --conf spark.kryoserializer.buffer.mb=4 \
-  --conf spark.kryo.referenceTracking=true \
-  --conf spark.executor.memory=${AVOCADO_EXECUTOR_MEMORY:-4g} \
-  ${AVOCADO_OPTS:- } \
-  --driver-memory ${AVOCADO_DRIVER_MEMORY:-4g} \
-  --jars "$AVOCADO_JARS" \
-  "$AVOCADO_CLI_JAR" \
-  "$@"
+  $SPARK_ARGS \
+  --jars $AVOCADO_JARS \
+  $AVOCADO_CLI_JAR \
+  ${AVOCADO_ARGS[@]}

--- a/bin/compute-avocado-jars.sh
+++ b/bin/compute-avocado-jars.sh
@@ -24,6 +24,6 @@ CLASSPATH=$("$AVOCADO_REPO"/bin/compute-avocado-classpath.sh)
 
 # list of jars to ship with spark; trim off the first and last from the CLASSPATH
 # TODO: brittle? assumes appassembler always puts the $BASE/etc first and the CLI jar last
-AVOCADO_JARS=$(echo "$CLASSPATH" | tr ":" "," | cut -d "," -f 2- | rev | cut -d "," -f 2- | rev)
+AVOCADO_JARS=$(echo "$CLASSPATH" | tr ":" "," | cut -d "," -f 2-)
 
 echo "$AVOCADO_JARS"

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,11 @@
         <version>1.10</version>
       </dependency>
       <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>1.3.2</version>
+      </dependency>
+      <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
         <version>2.0.23</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <java.version>1.7</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
-    <spark.version>1.2.0</spark.version>
+    <spark.version>1.4.1</spark.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
     <utils.version>0.2.2</utils.version>


### PR DESCRIPTION
Resolves #174 and #175.

Upgrading to Spark 1.4.1 is pretty uncontroversial.

The fix for #175 is unpleasant, and I wish I hadn't been the person to do it. Alas, the situation was that:

* You can't guarantee which machine is the master under YARN, so you can't load config from a local path.
* The config library that I use needs a file (for now).
* Spark's `CopyJar` functionality will not copy _directories_, so putting a directory on the classpath is a no-go.
* You can't make a file in a JAR on the classpath look like a _file_, you can only make it look like a string.

So, the "best" way to solve the problem was to put the config file into a randomly generated JAR, and to then open a stream to the file in the JAR, write that stream to a temp file on the YARN driver, and then read the config from that temp file.

Whatever!