### PR TITLE
[AVOCADO-232] Make move_to_* scripts rename artifacts.

### DIFF
--- a/avocado-cli/pom.xml
+++ b/avocado-cli/pom.xml
@@ -4,12 +4,12 @@
 
   <parent>
     <groupId>org.bdgenomics.avocado</groupId>
-    <artifactId>avocado-parent</artifactId>
+    <artifactId>avocado-parent_2.10</artifactId>
     <version>0.0.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>avocado-cli</artifactId>
+  <artifactId>avocado-cli_2.10</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>avocado-cli: Command line interface for a distributed variant caller</name>

--- a/avocado-core/pom.xml
+++ b/avocado-core/pom.xml
@@ -4,12 +4,12 @@
 
   <parent>
     <groupId>org.bdgenomics.avocado</groupId>
-    <artifactId>avocado-parent</artifactId>
+    <artifactId>avocado-parent_2.10</artifactId>
     <version>0.0.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>avocado-core</artifactId>
+  <artifactId>avocado-core_2.10</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>avocado-core: Core variant calling algorithms</name>

--- a/avocado-distribution/pom.xml
+++ b/avocado-distribution/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.avocado</groupId>
-    <artifactId>avocado-parent</artifactId>
+    <artifactId>avocado-parent_2.10</artifactId>
     <version>0.0.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   
-  <artifactId>avocado-distribution</artifactId>
+  <artifactId>avocado-distribution_2.10</artifactId>
   <packaging>pom</packaging>
   <name>avocado: distribution</name>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bdgenomics.avocado</groupId>
-  <artifactId>avocado-parent</artifactId>
+  <artifactId>avocado-parent_2.10</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>avocado: A Variant Caller, Distributed</name>

--- a/scripts/move_to_spark_2.sh
+++ b/scripts/move_to_spark_2.sh
@@ -17,7 +17,9 @@ substitution_cmd="s/_$svp/-spark2_$svp/g"
 find . -name "pom.xml" -exec sed \
     -e "/utils-/ s/_2\.1/-spark2_2.1/g" \
     -e "/adam-/ s/_2\.1/-spark2_2.1/g" \
+    -e "/avocado-/ s/_2\.1/-spark2_2.1/g" \
     -e "/utils-/ $substitution_cmd" \
     -e "/adam-/ $substitution_cmd" \
+    -e "/avocado-/ $substitution_cmd" \
     -e "/spark.version/ s/1.6.3/2.1.0/g" \
     -i.spark2.bak '{}' \;


### PR DESCRIPTION
Resolves #232. Added avocado pattern to `move_to_spark2.sh` and added Scala 2.10 suffixes to artifact names in POMs.