### PR TITLE
[AVOCADO-259] Do not specify htsjdk or Hadoop-BAM as dependencies.

### DIFF
--- a/avocado-core/pom.xml
+++ b/avocado-core/pom.xml
@@ -158,14 +158,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.seqdoop</groupId>
-      <artifactId>hadoop-bam</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.github.samtools</groupId>
-      <artifactId>htsjdk</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.6.0</hadoop.version>
     <utils.version>0.2.11</utils.version>
-    <htsjdk.version>2.5.0</htsjdk.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>
   
@@ -399,16 +398,6 @@
         <artifactId>breeze_2.10</artifactId>
         <version>0.10</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.seqdoop</groupId>
-        <artifactId>hadoop-bam</artifactId>
-        <version>7.7.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.samtools</groupId>
-        <artifactId>htsjdk</artifactId>
-        <version>${htsjdk.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.bdg-formats</groupId>


### PR DESCRIPTION
Resolves #259. Instead, rely on ADAM for transitive dependencies.