### PR TITLE
[AVOCADO-253] Add joint variant caller, direct save to VCF.

### DIFF
--- a/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/AvocadoMain.scala
+++ b/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/AvocadoMain.scala
@@ -32,6 +32,7 @@ private class AvocadoMain(args: Array[String]) extends Logging {
   private val commands: List[BDGCommandCompanion] = List(
     BiallelicGenotyper,
     DiscoverVariants,
+    Jointer,
     MergeDiscovered,
     Reassemble,
     TrioGenotyper)

--- a/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/Jointer.scala
+++ b/avocado-cli/src/main/scala/org/bdgenomics/avocado/cli/Jointer.scala
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.cli
+
+import htsjdk.samtools.ValidationStringency
+import org.apache.spark.SparkContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
+import org.bdgenomics.avocado.genotyping.JointAnnotatorCaller
+import org.bdgenomics.utils.cli._
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+
+object Jointer extends BDGCommandCompanion {
+  val commandName = "jointer"
+  val commandDescription = "Joint call and annotate variants."
+
+  def apply(cmdLine: Array[String]) = {
+    new Jointer(Args4j[JointerArgs](cmdLine))
+  }
+}
+
+class JointerArgs extends Args4jBase with ADAMSaveAnyArgs with ParquetArgs {
+  @Argument(required = true,
+    metaVar = "INPUT",
+    usage = "A globbed path of all genotyped variants",
+    index = 0)
+  var inputPath: String = null
+
+  @Argument(required = true,
+    metaVar = "OUTPUT",
+    usage = "Location to write the squared off VCF",
+    index = 1)
+  var outputPath: String = null
+
+  @Args4jOption(required = false,
+    name = "-single",
+    usage = "Save as a single VCF file.")
+  var asSingleFile: Boolean = false
+
+  @Args4jOption(required = false,
+    name = "-defer_merging",
+    usage = "Defers merging single file output.")
+  var deferMerging: Boolean = false
+
+  @Args4jOption(required = false,
+    name = "-disable_fast_concat",
+    usage = "Disables the parallel file concatenation engine.")
+  var disableFastConcat: Boolean = false
+
+  @Args4jOption(required = false,
+    name = "-stringency",
+    usage = "Stringency level for various checks; can be SILENT, LENIENT, or STRICT. Defaults to STRICT.")
+  var stringency: String = "STRICT"
+
+  // must be defined due to ADAMSaveAnyArgs, but unused here
+  var sortFastqOutput: Boolean = false
+}
+
+class Jointer(
+    protected val args: JointerArgs) extends BDGSparkCommand[JointerArgs] {
+
+  val companion = Jointer
+
+  def run(sc: SparkContext) {
+
+    val stringency = ValidationStringency.valueOf(args.stringency)
+
+    // load variants, drop duplicates, save
+    JointAnnotatorCaller(sc.loadGenotypes(args.inputPath))
+      .transform(_.cache)
+      .sort()
+      .saveAsVcf(args, stringency = stringency)
+  }
+}

--- a/avocado-core/pom.xml
+++ b/avocado-core/pom.xml
@@ -155,11 +155,6 @@
     <dependency>
       <groupId>org.scalanlp</groupId>
       <artifactId>breeze_2.10</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bdgenomics.bdg-formats</groupId>
-      <artifactId>bdg-formats</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/JointAnnotatorCaller.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/JointAnnotatorCaller.scala
@@ -1,0 +1,268 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.genotyping
+
+import breeze.stats.distributions.Binomial
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.VariantContext
+import org.bdgenomics.adam.rdd.variant.{
+  GenotypeRDD,
+  VariantContextRDD
+}
+import org.bdgenomics.adam.util.PhredUtils
+import org.bdgenomics.avocado.util.LogUtils
+import org.bdgenomics.formats.avro.{
+  Genotype,
+  GenotypeAllele,
+  Variant,
+  VariantAnnotation,
+  VariantCallingAnnotations
+}
+import scala.collection.JavaConversions._
+import scala.math.log
+
+/**
+ * Jointly calls variants and computes variant annotations.
+ */
+object JointAnnotatorCaller extends Serializable {
+
+  private val MINUS_TEN_DIV_LOG10 = -10.0 / log(10.0)
+
+  /**
+   * Jointly calls variants and computes variant annotations.
+   *
+   * @param genotypes The genotypes to jointly process.
+   * @return Returns a squared off and annotated set of variant contexts.
+   */
+  def apply(genotypes: GenotypeRDD): VariantContextRDD = {
+    genotypes.toVariantContexts
+      .transform(_.flatMap(annotateSite))
+  }
+
+  /**
+   * Jointly calls and annotates a single site.
+   *
+   * If the site is not variant, we discard the site.
+   *
+   * @param site The variant site to annotate.
+   * @return Returns an annotated and jointly called site.
+   */
+  private[genotyping] def annotateSite(
+    site: VariantContext): Option[VariantContext] = {
+
+    // calculate allele frequency
+    // if 0, then we can discard this site
+    val minorAlleleFrequency = calculateMinorAlleleFrequency(site)
+
+    if (minorAlleleFrequency <= 0.0) {
+      None
+    } else {
+
+      // if we have more than one sample, roll up annotations
+      val optAnnotations = if (site.genotypes.size > 1) {
+        Some(calculateAnnotations(site))
+      } else {
+        None
+      }
+
+      // update the genotypes with our allele frequency
+      val updatedGenotypes = recallGenotypes(site,
+        minorAlleleFrequency)
+
+      // compute the variant quality
+      val variantQuality = computeQuality(updatedGenotypes)
+
+      // make the new variant
+      val newVariant = optAnnotations.fold(
+        Variant.newBuilder(site.variant.variant))(annotations => {
+          Variant.newBuilder(site.variant.variant)
+            .setAnnotation(annotations)
+        }).setQuality(variantQuality)
+        .build
+
+      Some(VariantContext(newVariant, updatedGenotypes))
+    }
+  }
+
+  /**
+   * Calculates the frequency of alternate alleles at a site.
+   *
+   * @param The site to compute allele frequency for.
+   * @return The frequency of alternate alleles.
+   */
+  private[genotyping] def calculateMinorAlleleFrequency(
+    site: VariantContext): Double = {
+
+    val calledAlleles = site.genotypes.map(gt => {
+      gt.getAlleles.count(_ != GenotypeAllele.NO_CALL)
+    }).sum
+    val altAlleles = site.genotypes.map(gt => {
+      gt.getAlleles.count(_ == GenotypeAllele.ALT)
+    }).sum
+
+    altAlleles.toDouble / calledAlleles.toDouble
+  }
+
+  /**
+   * Computes rolled up statistical annotations.
+   *
+   * Computes:
+   *
+   * - Allelic depth
+   * - Strand bias components
+   *
+   * @param site The site to roll up annotations for.
+   * @return A new variant annotation.
+   */
+  private[genotyping] def calculateAnnotations(
+    site: VariantContext): VariantAnnotation = {
+
+    site.genotypes.map(VariantSummary(_))
+      .reduce(_.merge(_))
+      .toAnnotation(site.variant.variant)
+  }
+
+  /**
+   * Recalls the genotypes given the estimated allele frequency.
+   *
+   * @param site The site to rescore genotypes for.
+   * @param minorAlleleFrequency The computed alternate allele frequency.
+   * @return The new genotype calls to emit.
+   */
+  private[genotyping] def recallGenotypes(
+    site: VariantContext,
+    minorAlleleFrequency: Double): Iterable[Genotype] = {
+
+    // if the minor allele frequency is well defined,
+    // precompute the prior distributions for all copy number we have
+    val priorDistributions: Map[Int, Seq[Double]] = if (minorAlleleFrequency >= 1.0 ||
+      minorAlleleFrequency <= 0.0) {
+      Map.empty
+    } else {
+      site.genotypes.map(gt => {
+        gt.getAlleles.size
+      }).toSet
+        .map((cn: Int) => {
+          val dist = Binomial(cn, minorAlleleFrequency)
+
+          (cn -> (0 to cn).map(c => {
+            dist.logProbabilityOf(c)
+          }))
+        }).toMap
+    }
+
+    site.genotypes.map(recallGenotype(_, priorDistributions))
+  }
+
+  private def recallGenotype(gt: Genotype,
+                             priors: Map[Int, Seq[Double]]): Genotype = {
+
+    val others = gt.getAlleles.count(a => {
+      (a == GenotypeAllele.OTHER_ALT ||
+        a == GenotypeAllele.NO_CALL)
+    })
+
+    // are the priors defined? if not, just normalize
+    // also, skip everything if a no-call/other-alt
+    if (priors.nonEmpty && others == 0) {
+
+      // get the prior for our copy number
+      val prior = priors(gt.getAlleles.size)
+
+      // merge the prior with the likelihoods
+      val nonNormalizedPosterior = new Array[Double](
+        gt.getGenotypeLikelihoods.size)
+      nonNormalizedPosterior.indices
+        .foreach(idx => {
+          nonNormalizedPosterior(idx) = (prior(idx) +
+            gt.getGenotypeLikelihoods.get(idx))
+        })
+
+      // normalize the posterior
+      val posterior = LogUtils.logNormalize(nonNormalizedPosterior)
+        .map(d => d.toFloat: java.lang.Float)
+
+      // javafy the prior
+      val jPrior = prior.map(d => d.toFloat: java.lang.Float)
+
+      // recompute state and quality
+      val (state, quality) = BiallelicGenotyper.genotypeStateAndQuality(
+        nonNormalizedPosterior)
+
+      // update the current annotations, if available
+      val vca = Option(gt.getVariantCallingAnnotations).fold(
+        VariantCallingAnnotations.newBuilder)(v => {
+          VariantCallingAnnotations.newBuilder(v)
+        }).setGenotypePosteriors(posterior.toSeq)
+        .setGenotypePriors(jPrior)
+        .build
+
+      // build the genotype call array
+      val alleles = Seq.fill(state)({
+        GenotypeAllele.ALT
+      }) ++ Seq.fill(gt.getAlleles.size - state)({
+        GenotypeAllele.REF
+      })
+
+      Genotype.newBuilder(gt)
+        .setVariantCallingAnnotations(vca)
+        .setGenotypeQuality(quality.toInt)
+        .setAlleles(alleles)
+        .build
+    } else if (others == 0) {
+
+      // normalize the likelihoods
+      val posterior = LogUtils.logNormalize(gt.getGenotypeLikelihoods
+        .map(d => d: Double)
+        .toArray)
+        .map(d => d.toFloat: java.lang.Float)
+
+      // update the current annotations, if available
+      val vca = Option(gt.getVariantCallingAnnotations).fold(
+        VariantCallingAnnotations.newBuilder)(v => {
+          VariantCallingAnnotations.newBuilder(v)
+        }).setGenotypePosteriors(posterior.toSeq)
+        .build
+
+      Genotype.newBuilder(gt)
+        .setVariantCallingAnnotations(vca)
+        .build
+    } else {
+      gt
+    }
+  }
+
+  /**
+   * Computes the variant quality at this site.
+   *
+   * @param genotypes The genotypes called at this site.
+   * @return Returns the Phred scaled probability that this site is variant.
+   */
+  private[genotyping] def computeQuality(
+    genotypes: Iterable[Genotype]): Double = {
+
+    MINUS_TEN_DIV_LOG10 * genotypes.flatMap(gt => {
+      Option(gt.getVariantCallingAnnotations)
+        .flatMap(vca => {
+          Option(vca.getGenotypePosteriors)
+        }).flatMap(posteriors => {
+          posteriors.headOption
+        }).map(_.toDouble)
+    }).sum
+  }
+}

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/VariantSummary.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/VariantSummary.scala
@@ -1,0 +1,146 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.genotyping
+
+import org.bdgenomics.formats.avro.{
+  Genotype,
+  Variant,
+  VariantAnnotation
+}
+import scala.collection.JavaConversions._
+
+/**
+ * Helper object for creating variant summaries.
+ */
+private[genotyping] object VariantSummary {
+
+  /**
+   * Extracts a variant summary from a single genotype.
+   *
+   * @param g The genotype to extract variant level stats from.
+   * @return Returns a variant summary from the variant calling annotations
+   *   attached to this genotype.
+   */
+  def apply(g: Genotype): VariantSummary = {
+    val readDepth = Option(g.getReadDepth)
+      .map(i => i: Int)
+    val referenceReadDepth = Option(g.getReferenceReadDepth)
+      .map(i => i: Int)
+
+    val (frd, rrd, frrd, rrrd) = if (g.getStrandBiasComponents.isEmpty) {
+      (None, None, None, None)
+    } else {
+      val sbc: Seq[Int] = g.getStrandBiasComponents
+        .map(i => i: Int)
+      require(sbc.size == 4,
+        "Genotype (%s) has an illegal number of strand bias components.".format(g))
+
+      // strand bias component:
+      // 0,1 --> ref
+      // 2,3 --> alt
+      // 0,2 --> fwd
+      // 1,3 --> rev
+      val rfs = sbc(0)
+      val rrs = sbc(1)
+      val afs = sbc(2)
+      val ars = sbc(3)
+
+      (Some(rfs + afs), Some(rrs + ars),
+        Some(rfs), Some(rrs))
+    }
+
+    VariantSummary(readDepth, referenceReadDepth,
+      frd, rrd,
+      frrd, rrrd)
+  }
+}
+
+/**
+ * A roll-up of genotype stats to the variant level.
+ *
+ * @param readDepth The number of reads seen at this site.
+ * @param referenceReadDepth The number of reads supporting the reference.
+ * @param forwardReadDepth The number of reads mapped on the forward strand.
+ * @param reverseReadDepth The number of reads mapped on the reverse strand.
+ * @param forwardReferenceReadDepth The number of reads that support the
+ *   reference that mapped on the forward strand.
+ * @param reverseReferenceReadDepth The number of reads that support the
+ *   reference that mapped on the reverse strand.
+ */
+private[genotyping] case class VariantSummary(
+    readDepth: Option[Int],
+    referenceReadDepth: Option[Int],
+    forwardReadDepth: Option[Int],
+    reverseReadDepth: Option[Int],
+    forwardReferenceReadDepth: Option[Int],
+    reverseReferenceReadDepth: Option[Int]) {
+
+  private def mergeOptions(o1: Option[Int],
+                           o2: Option[Int]): Option[Int] = {
+    (o1, o2) match {
+      case (Some(a), Some(b)) => Some(a + b)
+      case (Some(a), None)    => Some(a)
+      case (None, Some(b))    => Some(b)
+      case (None, None)       => None
+    }
+  }
+
+  /**
+   * Merges two variant summaries together.
+   *
+   * @param vs The variant summary to merge into this summary.
+   * @return Aggregates the statistics between the two summaries.
+   */
+  def merge(vs: VariantSummary): VariantSummary = {
+    VariantSummary(
+      mergeOptions(readDepth, vs.readDepth),
+      mergeOptions(referenceReadDepth, vs.referenceReadDepth),
+      mergeOptions(forwardReadDepth, vs.forwardReadDepth),
+      mergeOptions(reverseReadDepth, vs.reverseReadDepth),
+      mergeOptions(forwardReferenceReadDepth, vs.forwardReferenceReadDepth),
+      mergeOptions(reverseReferenceReadDepth, vs.reverseReferenceReadDepth))
+  }
+
+  /**
+   * Converts this summary into a variant annotation.
+   *
+   * @param variant The variant to base this annotation on. Used to get the
+   *   current annotations on the variant.
+   * @return Returns a new variant annotation object.
+   */
+  def toAnnotation(v: Variant): VariantAnnotation = {
+    val vab = Option(v.getAnnotation).fold(VariantAnnotation.newBuilder)(va => {
+      VariantAnnotation.newBuilder(va)
+    })
+
+    readDepth.map(i => i: java.lang.Integer)
+      .foreach(vab.setReadDepth)
+    referenceReadDepth.map(i => i: java.lang.Integer)
+      .foreach(vab.setReferenceReadDepth)
+    forwardReadDepth.map(i => i: java.lang.Integer)
+      .foreach(vab.setForwardReadDepth)
+    reverseReadDepth.map(i => i: java.lang.Integer)
+      .foreach(vab.setReverseReadDepth)
+    forwardReferenceReadDepth.map(i => i: java.lang.Integer)
+      .foreach(vab.setReferenceForwardReadDepth)
+    reverseReferenceReadDepth.map(i => i: java.lang.Integer)
+      .foreach(vab.setReferenceReverseReadDepth)
+
+    vab.build
+  }
+}

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/util/LogUtils.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/util/LogUtils.scala
@@ -55,6 +55,17 @@ object LogUtils extends Serializable {
   }
 
   /**
+   * Normalizes an array of log likelihoods.
+   *
+   * @param pArray The array to normalize.
+   * @return Returns a normalized array.
+   */
+  def logNormalize(pArray: Array[Double]): Array[Double] = {
+    val sum = sumLogProbabilities(pArray)
+    pArray.map(_ - sum)
+  }
+
+  /**
    * This is a nifty little trick for summing logs. Not sure exactly where it's
    * originally from, but apparently Durbin et al '98 features it. evidently:
    * log(p + q) = log(p(1 + q/p)

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/genotyping/JointAnnotatorCallerSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/genotyping/JointAnnotatorCallerSuite.scala
@@ -1,0 +1,255 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.genotyping
+
+import org.bdgenomics.adam.models.VariantContext
+import org.bdgenomics.avocado.AvocadoFunSuite
+import org.bdgenomics.formats.avro.{
+  Genotype,
+  GenotypeAllele,
+  Variant,
+  VariantCallingAnnotations
+}
+import org.bdgenomics.utils.misc.MathUtils
+import scala.collection.JavaConversions._
+
+class JointAnnotatorCallerSuite extends AvocadoFunSuite {
+
+  val baseGt = Genotype.newBuilder
+    .setContigName("chr1")
+    .setStart(1000)
+    .setEnd(1001)
+    .setVariant(Variant.newBuilder
+      .setAlternateAllele("A")
+      .setReferenceAllele("G")
+      .build)
+    .build
+
+  test("discard reference site") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF, GenotypeAllele.REF))
+        .build)
+
+    val optNewSite = JointAnnotatorCaller.annotateSite(
+      VariantContext.buildFromGenotypes(genotypes))
+
+    assert(optNewSite.isEmpty)
+  }
+
+  test("calculate MAF for all called genotypes") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF, GenotypeAllele.ALT))
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF, GenotypeAllele.REF))
+        .build)
+    val af = JointAnnotatorCaller.calculateMinorAlleleFrequency(
+      VariantContext.buildFromGenotypes(genotypes))
+
+    assert(MathUtils.fpEquals(af, 0.25))
+  }
+
+  test("calculate MAF ignoring uncalled genotypes") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF,
+          GenotypeAllele.REF,
+          GenotypeAllele.ALT))
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.OTHER_ALT))
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.NO_CALL, GenotypeAllele.NO_CALL))
+        .build)
+    val af = JointAnnotatorCaller.calculateMinorAlleleFrequency(
+      VariantContext.buildFromGenotypes(genotypes))
+
+    assert(MathUtils.fpEquals(af, 0.25))
+  }
+
+  test("roll up variant annotations from a single genotype") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setReadDepth(10)
+        .setReferenceReadDepth(5)
+        .setAlternateReadDepth(5)
+        .setStrandBiasComponents(Seq(4, 1, 2, 3)
+          .map(i => i: java.lang.Integer))
+        .build)
+
+    val annotation = JointAnnotatorCaller.calculateAnnotations(
+      VariantContext.buildFromGenotypes(genotypes))
+
+    assert(annotation.getReadDepth === 10)
+    assert(annotation.getReferenceReadDepth === 5)
+    assert(annotation.getReferenceForwardReadDepth === 4)
+    assert(annotation.getReferenceReverseReadDepth === 1)
+    assert(annotation.getForwardReadDepth === 6)
+    assert(annotation.getReverseReadDepth === 4)
+  }
+
+  test("roll up variant annotations across multiple genotypes") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setReadDepth(10)
+        .setReferenceReadDepth(5)
+        .setAlternateReadDepth(5)
+        .setStrandBiasComponents(Seq(4, 1, 2, 3)
+          .map(i => i: java.lang.Integer))
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setReadDepth(7)
+        .setReferenceReadDepth(5)
+        .setAlternateReadDepth(2)
+        .setStrandBiasComponents(Seq(3, 2, 1, 1)
+          .map(i => i: java.lang.Integer))
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setReadDepth(9)
+        .setReferenceReadDepth(9)
+        .setAlternateReadDepth(0)
+        .build)
+
+    val annotation = JointAnnotatorCaller.calculateAnnotations(
+      VariantContext.buildFromGenotypes(genotypes))
+
+    assert(annotation.getReadDepth === 26)
+    assert(annotation.getReferenceReadDepth === 19)
+    assert(annotation.getReferenceForwardReadDepth === 7)
+    assert(annotation.getReferenceReverseReadDepth === 3)
+    assert(annotation.getForwardReadDepth === 10)
+    assert(annotation.getReverseReadDepth === 7)
+  }
+
+  test("recalling genotypes is a no-op for no calls and complex hets") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF, GenotypeAllele.NO_CALL))
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.OTHER_ALT, GenotypeAllele.NO_CALL))
+        .build)
+
+    val newGenotypes = JointAnnotatorCaller.recallGenotypes(
+      VariantContext.buildFromGenotypes(genotypes), 0.5)
+
+    genotypes.zip(newGenotypes)
+      .foreach(p => assert(p._1 === p._2))
+  }
+
+  test("recall a genotype so that the state changes") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF, GenotypeAllele.ALT))
+        .setGenotypeLikelihoods(Seq(0.0, 0.0, 0.0)
+          .map(d => d: java.lang.Double))
+        .build)
+
+    val newGenotypes = JointAnnotatorCaller.recallGenotypes(
+      VariantContext.buildFromGenotypes(genotypes), 0.9)
+
+    assert(newGenotypes.size === 1)
+    val newGenotype = newGenotypes.head
+    assert(newGenotype.getAlleles.count(_ == GenotypeAllele.ALT) === 2)
+    val posteriors = newGenotype.getVariantCallingAnnotations
+      .getGenotypePosteriors
+    assert(posteriors.size === 3)
+    assert(MathUtils.fpEquals(posteriors.get(0).toDouble, -4.60517018599))
+    assert(MathUtils.fpEquals(posteriors.get(1).toDouble, -1.71479842809))
+    assert(MathUtils.fpEquals(posteriors.get(2).toDouble, -0.21072103131))
+    val priors = newGenotype.getVariantCallingAnnotations
+      .getGenotypePriors
+    assert(priors.size === 3)
+    assert(MathUtils.fpEquals(priors.get(0).toDouble, -4.60517018599))
+    assert(MathUtils.fpEquals(priors.get(1).toDouble, -1.71479842809))
+    assert(MathUtils.fpEquals(priors.get(2).toDouble, -0.21072103131))
+    assert(newGenotype.getGenotypeQuality === 6)
+  }
+
+  test("allele frequency being outside of (0.0, 1.0) just computes posteriors") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setAlleles(Seq(GenotypeAllele.REF, GenotypeAllele.ALT))
+        .setGenotypeLikelihoods(Seq(0.0, 1.0, 0.0)
+          .map(d => d: java.lang.Double))
+        .build)
+
+    val newGenotypes = JointAnnotatorCaller.recallGenotypes(
+      VariantContext.buildFromGenotypes(genotypes), 0.0)
+
+    assert(newGenotypes.size === 1)
+    val newGenotype = newGenotypes.head
+    assert(newGenotype.getAlleles.count(_ == GenotypeAllele.ALT) === 1)
+    val posteriors = newGenotype.getVariantCallingAnnotations
+      .getGenotypePosteriors
+    assert(posteriors.size === 3)
+    assert(MathUtils.fpEquals(posteriors.get(0).toDouble, -1.55144471393))
+    assert(MathUtils.fpEquals(posteriors.get(1).toDouble, -0.55144471393))
+    assert(MathUtils.fpEquals(posteriors.get(2).toDouble, -1.55144471393))
+    assert(newGenotype.getVariantCallingAnnotations
+      .getGenotypePriors
+      .isEmpty)
+  }
+
+  test("compute variant quality from a single genotype") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setVariantCallingAnnotations(
+          VariantCallingAnnotations.newBuilder
+            .setGenotypePosteriors(Seq(-4.60517018599,
+              -2.40794560865,
+              -0.10536051565)
+              .map(_.toFloat)
+              .map(f => f: java.lang.Float))
+            .build)
+        .build)
+
+    assert(MathUtils.fpEquals(JointAnnotatorCaller.computeQuality(genotypes),
+      20.0))
+  }
+
+  test("compute variant quality from multiple genotypes") {
+    val genotypes = Seq(
+      Genotype.newBuilder(baseGt)
+        .setVariantCallingAnnotations(
+          VariantCallingAnnotations.newBuilder
+            .setGenotypePosteriors(Seq(-4.60517018599,
+              -2.40794560865,
+              -0.10536051565)
+              .map(_.toFloat)
+              .map(f => f: java.lang.Float))
+            .build)
+        .build,
+      Genotype.newBuilder(baseGt)
+        .setVariantCallingAnnotations(
+          VariantCallingAnnotations.newBuilder
+            .setGenotypePosteriors(Seq(-6.90775527898,
+              -0.00200200267
+                - 6.90775527898)
+              .map(_.toFloat)
+              .map(f => f: java.lang.Float))
+            .build)
+        .build)
+
+    assert(MathUtils.fpEquals(JointAnnotatorCaller.computeQuality(genotypes),
+      50.0))
+  }
+}

--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/genotyping/VariantSummarySuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/genotyping/VariantSummarySuite.scala
@@ -1,0 +1,141 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.genotyping
+
+import org.bdgenomics.formats.avro.{
+  Genotype,
+  Variant,
+  VariantAnnotation
+}
+import org.scalatest.FunSuite
+import scala.collection.JavaConversions._
+
+class VariantSummarySuite extends FunSuite {
+
+  test("create from genotype without strand bias components") {
+    val gt = Genotype.newBuilder
+      .setReadDepth(10)
+      .setReferenceReadDepth(5)
+      .build
+
+    val vs = VariantSummary(gt)
+
+    assert(vs.readDepth === Some(10))
+    assert(vs.referenceReadDepth === Some(5))
+    assert(vs.forwardReadDepth.isEmpty)
+    assert(vs.reverseReadDepth.isEmpty)
+    assert(vs.forwardReferenceReadDepth.isEmpty)
+    assert(vs.reverseReferenceReadDepth.isEmpty)
+  }
+
+  test("create from genotype with strand bias components") {
+    val gt = Genotype.newBuilder
+      .setReadDepth(10)
+      .setReferenceReadDepth(5)
+      .setStrandBiasComponents(Seq(2, 3, 4, 1).map(i => i: java.lang.Integer))
+      .build
+
+    val vs = VariantSummary(gt)
+
+    assert(vs.readDepth === Some(10))
+    assert(vs.referenceReadDepth === Some(5))
+    assert(vs.forwardReadDepth === Some(6))
+    assert(vs.reverseReadDepth === Some(4))
+    assert(vs.forwardReferenceReadDepth === Some(2))
+    assert(vs.reverseReferenceReadDepth === Some(3))
+  }
+
+  test("invalid strand bias causes exception") {
+    val gt = Genotype.newBuilder
+      .setStrandBiasComponents(Seq(0, 1, 2).map(i => i: java.lang.Integer))
+      .build
+
+    intercept[IllegalArgumentException] {
+      VariantSummary(gt)
+    }
+  }
+
+  test("merge two fully populated summaries") {
+    val vs1 = VariantSummary(Some(10),
+      Some(5),
+      Some(6),
+      Some(4),
+      Some(3),
+      Some(2))
+    val vs2 = VariantSummary(Some(12),
+      Some(7),
+      Some(6),
+      Some(4),
+      Some(6),
+      Some(2))
+
+    val va = vs1.merge(vs2)
+      .toAnnotation(Variant.newBuilder.build())
+
+    assert(va.getReadDepth === 22)
+    assert(va.getReferenceReadDepth === 12)
+    assert(va.getForwardReadDepth === 12)
+    assert(va.getReverseReadDepth === 8)
+    assert(va.getReferenceForwardReadDepth === 9)
+    assert(va.getReferenceReverseReadDepth === 4)
+  }
+
+  test("merge two partially populated summaries") {
+    val vs1 = VariantSummary(Some(0),
+      Some(1),
+      Some(1),
+      None,
+      Some(3),
+      None)
+    val vs2 = VariantSummary(Some(0),
+      None,
+      Some(1),
+      None,
+      None,
+      None)
+    val vm = vs1.merge(vs2)
+
+    assert(vm.readDepth === Some(0))
+    assert(vm.referenceReadDepth === Some(1))
+    assert(vm.forwardReadDepth === Some(2))
+    assert(vm.reverseReadDepth.isEmpty)
+    assert(vm.forwardReferenceReadDepth === Some(3))
+    assert(vm.reverseReferenceReadDepth.isEmpty)
+  }
+
+  test("populating an annotation should carry old fields") {
+    val va = VariantAnnotation.newBuilder
+      .setReadDepth(6)
+      .setReferenceReadDepth(2)
+      .setForwardReadDepth(3)
+      .setReferenceForwardReadDepth(2)
+      .setReverseReadDepth(1)
+      .setReferenceReverseReadDepth(0)
+      .build
+    val v = Variant.newBuilder
+      .setAnnotation(va)
+      .build
+
+    val newVa = VariantSummary(None, None,
+      None, None,
+      None, None)
+      .toAnnotation(v)
+
+    assert(newVa === va)
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -396,13 +396,8 @@
       <dependency>
         <groupId>org.scalanlp</groupId>
         <artifactId>breeze_2.10</artifactId>
-        <version>0.10</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.bdgenomics.bdg-formats</groupId>
-        <artifactId>bdg-formats</artifactId>
-        <version>0.11.1</version>
+        <version>0.13.2</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Resolves #199, #253. Adds back a joint variant caller that computes rolled up variant level statistics and that saves directly out to VCF. This uses a binomial prior based on the alternate allele frequency to update the genotypes. We use the posteriors to generate the variant quality score.