### PR TITLE
[AVOCADO-295] Set correct index when checking quality score during variant discovery.

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/DiscoverVariants.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/DiscoverVariants.scala
@@ -196,7 +196,7 @@ object DiscoverVariants extends Serializable with Logging {
                 (sequence(idx + length - 1).toString, variants)
               })(ref => {
                 val newVars = (0 until length).flatMap(i => {
-                  if (qual(i).toInt - 33 >= phredThreshold) {
+                  if (qual(idx + i).toInt - 33 >= phredThreshold) {
                     Some(DiscoveredVariant(
                       contigName,
                       pos + i,


### PR DESCRIPTION
Resolves #295. @jpdna I'll test this and let you know if this winds up being much of an accuracy change. Thanks for catching this! Also, this needs some more tests to catch the bad behavior.