### PR TITLE
Fixed parameter names in method documentations.

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/BiallelicGenotyper.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/BiallelicGenotyper.scala
@@ -187,7 +187,7 @@ private[avocado] object BiallelicGenotyper extends Serializable with Logging {
    * Scores the putative variants covered by a read against a single read.
    *
    * @param readAndVariants A tuple pairing a read with the variants it covers.
-   * @param copyNumberVariants Any known copy number variants that exist at this site.
+   * @param copyNumber A class holding information about copy number across the genome.
    * @param scoreAllSites If true, calculates likelihoods for all sites, and not
    *   just variant sites.
    * @return Returns an iterable collection of (Variant, Observation) pairs.
@@ -572,7 +572,7 @@ private[avocado] object BiallelicGenotyper extends Serializable with Logging {
   private val TEN_DIV_LOG10 = 10.0 / mathLog(10.0)
 
   /**
-   * @param logLikelihood The log likelihoods of an observed call.
+   * @param obs A variant observation to get genotype state and quality of.
    * @return Returns a tuple containing the (number of alt, ref, and otheralt
    *   alleles, quality).
    */
@@ -616,7 +616,7 @@ private[avocado] object BiallelicGenotyper extends Serializable with Logging {
   }
 
   /**
-   * @param logLikelihood The log likelihoods of an observed call.
+   * @param logLikelihoods The log likelihoods of an observed call.
    * @return Returns a tuple containing the (genotype state, quality).
    */
   private[genotyping] def genotypeStateAndQuality(
@@ -766,11 +766,11 @@ private[avocado] object BiallelicGenotyper extends Serializable with Logging {
    *
    * @param otherFwd The number of reads that don't support this allele that are
    *   mapped on the forward strand.
-   * @param otherRef The number of reads that don't support this allele that are
+   * @param otherRev The number of reads that don't support this allele that are
    *   mapped on the reverse strand.
    * @param alleleFwd The number of reads that support this allele that are
    *   mapped on the forward strand.
-   * @param alleleRef The number of reads that support this allele that are
+   * @param alleleRev The number of reads that support this allele that are
    *   mapped on the reverse strand.
    * @return Returns the Phred scaled P-value for whether there is a significant
    *   difference between the strand biases for the two alleles.
@@ -780,18 +780,18 @@ private[avocado] object BiallelicGenotyper extends Serializable with Logging {
                                  alleleFwd: Int,
                                  alleleRev: Int): Float = {
 
-    val numerator = (logFactorial(otherFwd + otherRev) +
+    val numerator = logFactorial(otherFwd + otherRev) +
       logFactorial(otherFwd + alleleFwd) +
       logFactorial(alleleFwd + alleleRev) +
-      logFactorial(otherRev + alleleRev))
-    val denominator = (logFactorial(otherFwd) +
+      logFactorial(otherRev + alleleRev)
+    val denominator = logFactorial(otherFwd) +
       logFactorial(otherRev) +
       logFactorial(alleleFwd) +
       logFactorial(alleleRev) +
       logFactorial(otherFwd +
         otherRev +
         alleleFwd +
-        alleleRev))
+        alleleRev)
 
     LogPhred.logErrorToPhred(numerator - denominator).toFloat
   }

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/DiscoverVariants.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/DiscoverVariants.scala
@@ -43,7 +43,7 @@ object DiscoverVariants extends Serializable with Logging {
   /**
    * Discovers all variants in an RDD of reads.
    *
-   * @param rdd RDD of reads.
+   * @param aRdd RDD of reads.
    * @param optPhredThreshold An optional threshold that discards all variants
    *   not supported by bases of at least a given phred score.
    * @return Returns an RDD of variants.

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/JointAnnotatorCaller.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/JointAnnotatorCaller.scala
@@ -111,7 +111,7 @@ object JointAnnotatorCaller extends Serializable {
   /**
    * Calculates the frequency of alternate alleles at a site.
    *
-   * @param The site to compute allele frequency for.
+   * @param site The site to compute allele frequency for.
    * @return The frequency of alternate alleles.
    */
   private[genotyping] def calculateMinorAlleleFrequency(

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/VariantSummary.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/genotyping/VariantSummary.scala
@@ -119,7 +119,7 @@ private[genotyping] case class VariantSummary(
   /**
    * Converts this summary into a variant annotation.
    *
-   * @param variant The variant to base this annotation on. Used to get the
+   * @param v The variant to base this annotation on. Used to get the
    *   current annotations on the variant.
    * @return Returns a new variant annotation object.
    */

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/models/Observation.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/models/Observation.scala
@@ -60,7 +60,7 @@ object Observation {
  *   allele were observed.
  * @param otherLogLikelihoods The log likelihoods that 0...n copies of another
  *   allele were observed.
- * @param otherLogLikelihoods The log likelihoods that 0...n copies of an
+ * @param nonRefLogLikelihoods The log likelihoods that 0...n copies of an
  *   unknown allele were observed.
  * @param alleleCoverage The total number of reads observed that cover the
  *   site and match the allele.

--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/realigner/Realigner.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/realigner/Realigner.scala
@@ -118,7 +118,7 @@ object Realigner extends Logging {
    * Extracts the reference, segments out the alignment blocks, and realigns.
    *
    * @param read Read to realign.
-   * @param alignment The candidate realignment blocks.
+   * @param realignmentBlocks The candidate realignment blocks.
    * @param kmerLength The length k of the k-mers.
    * @return Returns a read
    */


### PR DESCRIPTION
There were a few locations where parameter names were documented inconsistently. This PR fixes some of those places.